### PR TITLE
Sbig ethernet support

### DIFF
--- a/src/chimera/instruments/sbig/sbig.py
+++ b/src/chimera/instruments/sbig/sbig.py
@@ -237,6 +237,10 @@ class SBIG(CameraBase, FilterWheelBase):
         
         # ok, start it
         self.exposeBegin(imageRequest)
+
+        (mode, binning, top,  left,
+         width, height) = self._getReadoutModeInfo(imageRequest["binning"],
+                                                   imageRequest["window"])
         
         self.drv.startExposure(self.ccd,
                                int(imageRequest["exptime"]*100), shutter)

--- a/src/chimera/instruments/sbig/sbig.py
+++ b/src/chimera/instruments/sbig/sbig.py
@@ -49,13 +49,6 @@ class SBIG(CameraBase, FilterWheelBase):
         self.drv = SBIGDrv()
         self.ccd = SBIGDrv.imaging
 
-        self.ipaddr = None
-        if self['device'] == 'USB':
-            self.dev = SBIGDrv.usb
-        elif self['device'].startswith('ETH:'):
-            self.dev = SBIGDrv.eth
-            self.ipaddr = struct.unpack('I', struct.pack('BBBB', *map(int, self['device'].split(':')[1].split('.')))[::-1])[0]
-
         self.lastTemp = 0
         self.lastFilter = None
 
@@ -96,6 +89,13 @@ class SBIG(CameraBase, FilterWheelBase):
             self.ccd = SBIGDrv.imaging
         else:
             self.ccd = SBIGDrv.tracking
+
+        self.ipaddr = None
+        if self['device'] == 'USB':
+            self.dev = SBIGDrv.usb
+        elif self['device'].startswith('ETH:'):
+            self.dev = SBIGDrv.eth
+            self.ipaddr = struct.unpack('I', struct.pack('BBBB', *map(int, self['device'].split(':')[1].split('.')))[::-1])[0]
 
         self.open(self.dev, self.ipaddr)
 

--- a/src/chimera/instruments/sbig/sbig.py
+++ b/src/chimera/instruments/sbig/sbig.py
@@ -243,7 +243,8 @@ class SBIG(CameraBase, FilterWheelBase):
                                                    imageRequest["window"])
         
         self.drv.startExposure(self.ccd,
-                               int(imageRequest["exptime"]*100), shutter)
+                               int(imageRequest["exptime"]*100), shutter,
+                               mode=mode.mode, window=(top, left, width, height))
         
         # save time exposure started
         self.lastFrameStartTime = dt.datetime.utcnow()

--- a/src/chimera/instruments/sbig/sbig.py
+++ b/src/chimera/instruments/sbig/sbig.py
@@ -23,6 +23,8 @@ from __future__ import division
 import time
 import datetime as dt
 import numpy as N
+
+import struct
         
 from chimera.instruments.sbig.sbigdrv import (SBIGDrv, SBIGException)
 
@@ -34,7 +36,11 @@ from chimera.instruments.filterwheel import FilterWheelBase
 from chimera.core.lock import lock
 
 
-class SBIG(CameraBase, FilterWheelBase):  
+class SBIG(CameraBase, FilterWheelBase):
+
+    __config__ = {
+        'device': 'USB'
+        }
 
     def __init__(self):
         CameraBase.__init__ (self)
@@ -42,7 +48,13 @@ class SBIG(CameraBase, FilterWheelBase):
 
         self.drv = SBIGDrv()
         self.ccd = SBIGDrv.imaging
-        self.dev = SBIGDrv.usb
+
+        self.ipaddr = None
+        if self['device'] == 'USB':
+            self.dev = SBIGDrv.usb
+        elif self['device'].startswith('ETH:'):
+            self.dev = SBIGDrv.eth
+            self.ipaddr = struct.unpack('I', struct.pack('BBBB', *map(int, self['device'].split(':')[1].split('.')))[::-1])[0]
 
         self.lastTemp = 0
         self.lastFilter = None
@@ -85,7 +97,7 @@ class SBIG(CameraBase, FilterWheelBase):
         else:
             self.ccd = SBIGDrv.tracking
 
-        self.open(self.dev)
+        self.open(self.dev, self.ipaddr)
 
         # make sure filter wheel is in the right position
         self.setFilter(self.getFilters()[0])
@@ -102,9 +114,9 @@ class SBIG(CameraBase, FilterWheelBase):
         except SBIGException: pass
 
     @lock
-    def open(self, device):
+    def open(self, device, ipaddr=None):
         self.drv.openDriver()
-        self.drv.openDevice(device)
+        self.drv.openDevice(device, ipaddr)
         self.drv.establishLink()
         self.drv.queryCCDInfo()
         return True

--- a/src/chimera/instruments/sbig/sbigdrv.py
+++ b/src/chimera/instruments/sbig/sbigdrv.py
@@ -123,6 +123,7 @@ class SBIGDrv(object):
     usb2 = udrv.DEV_USB2
     usb3 = udrv.DEV_USB3
     usb4 = udrv.DEV_USB4
+    eth  = udrv.DEV_ETH
     
     imaging = udrv.CCD_IMAGING
     tracking = udrv.CCD_TRACKING
@@ -168,10 +169,12 @@ class SBIGDrv(object):
     def closeDriver(self):
         return self._cmd(udrv.CC_CLOSE_DRIVER, None, None)
 
-    def openDevice(self, device):
+    def openDevice(self, device, ipaddr=None):
 
         odp = udrv.OpenDeviceParams()
         odp.deviceType = device
+        if ipaddr:
+            odp.ipAddress = ipaddr
 
         try:
             return self._cmd(udrv.CC_OPEN_DEVICE, odp, None)

--- a/src/chimera/instruments/sbig/sbigdrv.py
+++ b/src/chimera/instruments/sbig/sbigdrv.py
@@ -204,15 +204,27 @@ class SBIGDrv(object):
         self._cmd(udrv.CC_GET_LINK_STATUS, None, glsr)
         return bool(glsr.linkEstablished)
 
-    def startExposure(self, ccd, exp_time, shutter):
-        sep = udrv.StartExposureParams()
+    def startExposure(self, ccd, exp_time, shutter, mode = 0, window = None):
+
+        # geometry checking
+        readoutMode = self.readoutModes[ccd][mode]
+
+        window = (window or []) or readoutMode.getWindow()
+        
+        sep = udrv.StartExposureParams2()
 
         sep.ccd = ccd
         sep.openShutter = shutter
         sep.abgState = 0
         sep.exposureTime = exp_time
+        sep.readoutMode = mode
+        sep.top    = window[0]
+        sep.left   = window[1]
+        sep.width  = window[2]
+        sep.height = window[3]
+        
 
-        return self._cmd(udrv.CC_START_EXPOSURE, sep, None)
+        return self._cmd(udrv.CC_START_EXPOSURE2, sep, None)
 
     def endExposure(self, ccd):
         eep = udrv.EndExposureParams()


### PR DESCRIPTION
Verified to work with ST-8XE and STX-16803.

Due to requirement of START_EXPOSURE2 for newer cameras (works for older ones as well) it requires newer python bindings to the sbig library (which seemingly is only provided in form of an dynamic library now).

Also one needs a certain LD_PRELOAD library for ethernet to work, since sbig wasn't able to use setsockopt correctly (at least not on modern linux kernels).