### PR TITLE
Python’s dict.has_key is deprecated.

### DIFF
--- a/src/chimera/util/image.py
+++ b/src/chimera/util/image.py
@@ -430,7 +430,7 @@ class Image (DictMixin, RemoteObject):
         return self._fd["PRIMARY"].header.items()
 
     def __contains__(self, key):
-        return self._fd["PRIMARY"].header.has_key(key)
+        return key in self._fd["PRIMARY"].header
 
     def __iter__(self):
         for k in self.keys():

--- a/src/chimera/util/output.py
+++ b/src/chimera/util/output.py
@@ -99,7 +99,7 @@ def nc_len(mystr):
 
 
 def xtermTitle(mystr):
-    if havecolor and dotitles and os.environ.has_key("TERM") and sys.stderr.isatty():
+    if havecolor and dotitles and "TERM" in os.environ and sys.stderr.isatty():
         myt = os.environ["TERM"]
         legal_terms = [
             "xterm", "Eterm", "aterm", "rxvt", "screen", "kterm", "rxvt-unicode"]


### PR DESCRIPTION
On newer versions of pyfits, has_key does not exists on the header.
