### PR TITLE
Fixes issue #39. 

### DIFF
--- a/src/chimera/interfaces/dome.py
+++ b/src/chimera/interfaces/dome.py
@@ -179,6 +179,14 @@ class Dome(Interface):
         @rtype: float
         """
 
+    def setTelescope(self,tel):
+        """
+        Set telescope to be tracked by dome.
+
+        @param tel: A string specifying the telescope to be tracked by the dome.
+        """
+        self["telescope"] = tel
+
     @event
     def syncBegin(self):
         """

--- a/src/scripts/chimera-dome
+++ b/src/scripts/chimera-dome
@@ -88,7 +88,7 @@ class ChimeraDome (ChimeraCLI):
     def track(self, options):
 
         if options.telescope:
-            self.dome["telescope"] = options.telescope
+            self.dome.setTelescope(options.telescope)
 
         self.out("Activating tracking ... ", end="")
         self.dome.track()


### PR DESCRIPTION
Created a function called "setTelescope" on "interface.dome" that receives a string and set the value of the configuration. For some reason item assignment does not work.