### PR TITLE
[chimera-cam] Print microseconds to DATE-OBS fits file header keyword.

### DIFF
--- a/src/chimera/util/image.py
+++ b/src/chimera/util/image.py
@@ -43,7 +43,7 @@ class ImageUtil (object):
         if type(datetime) == float:
             datetime = dt.datetime.fromtimestamp(datetime)
 
-        return datetime.strftime("%Y-%m-%dT%H:%M:%S")
+        return datetime.strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     @staticmethod
     def makeFilename(path='$DATE-$TIME',


### PR DESCRIPTION
It is important to increase the precision of the timestamp on the header when observing fast transits of objects like TNOs.