### PR TITLE
Chimera plugins

### DIFF
--- a/src/chimera/controllers/imageserver/util.py
+++ b/src/chimera/controllers/imageserver/util.py
@@ -11,7 +11,7 @@ def getImageServer(manager):
     except ObjectNotFoundException:
         try:
             toReturn = manager.addLocation(
-                '/ImageServer/imageserver', [ChimeraPath.controllers()])
+                '/ImageServer/imageserver', ChimeraPath().controllers)
         except Exception, e:
             print ''.join(Pyro.util.getPyroTraceback(e))
             raise ClassLoaderException('Unable to create imageserver')

--- a/src/chimera/controllers/site/main.py
+++ b/src/chimera/controllers/site/main.py
@@ -65,9 +65,11 @@ class SiteController (object):
         self.paths = {"instruments": [],
                       "controllers": []}
 
-        # add system path
-        self.paths["instruments"].append(ChimeraPath.instruments())
-        self.paths["controllers"].append(ChimeraPath.controllers())
+        # add system and plugins paths
+        Path = ChimeraPath()
+        self.paths["instruments"].extend(Path.instruments)
+        self.paths["controllers"].extend(Path.controllers)
+
 
     def parseArgs(self, args):
 
@@ -196,7 +198,7 @@ class SiteController (object):
         if not self.options.dry:
             log.info("Starting system.")
             log.info("Chimera: %s" % _chimera_version_)
-            log.info("Chimera prefix: %s" % ChimeraPath.root())
+            log.info("Chimera prefix: %s" % ChimeraPath().root())
             log.info("Python: %s" % platform.python_version())
             log.info("System: %s" % ' '.join(platform.uname()))
 

--- a/src/chimera/core/cli.py
+++ b/src/chimera/core/cli.py
@@ -394,7 +394,7 @@ class ChimeraCLI (object):
                                     long="instruments-dir",
                                     helpGroup="PATHS",
                                     type=ParameterType.INCLUDE_PATH,
-                                    default=[ChimeraPath.instruments()],
+                                    default=ChimeraPath().instruments,
                                     help="Append PATH to %s load path. "
                                     "This option could be setted multiple "
                                     "times to add multiple directories." %
@@ -415,7 +415,7 @@ class ChimeraCLI (object):
                                     long="controllers-dir",
                                     helpGroup="PATHS",
                                     type=ParameterType.INCLUDE_PATH,
-                                    default=[ChimeraPath.controllers()],
+                                    default=ChimeraPath().controllers,
                                     help="Append PATH to controllers load path. "
                                     "This option could be setted multiple "
                                     "times to add multiple directories.",

--- a/src/chimera/core/path.py
+++ b/src/chimera/core/path.py
@@ -8,7 +8,7 @@ class ChimeraPath (object):
 
     def __init__(self):
         # Search for chimera plugins on the sys.path
-        self._instruments_plugins, self._controllers_plugins = find_chimera_plugins()
+        self._controllers_plugins, self._instruments_plugins = find_chimera_plugins()
         self._instruments = [os.path.join(self.root(), 'instruments')]
         self._instruments.extend(self._instruments_plugins)
         self._controllers = [os.path.join(self.root(), 'controllers')]

--- a/src/chimera/core/path.py
+++ b/src/chimera/core/path.py
@@ -1,19 +1,27 @@
 import os
+from chimera.util.findplugins import find_chimera_plugins
 
 __all__ = ['ChimeraPath']
 
 
 class ChimeraPath (object):
 
+    def __init__(self):
+        # Search for chimera plugins on the sys.path
+        self._instruments_plugins, self._controllers_plugins = find_chimera_plugins()
+        self._instruments = [os.path.join(self.root(), 'instruments')]
+        self._instruments.extend(self._instruments_plugins)
+        self._controllers = [os.path.join(self.root(), 'controllers')]
+        self._controllers.extend(self._controllers_plugins)
+
     @staticmethod
     def root():
-        return os.path.realpath(
-            os.path.join(os.path.abspath(__file__), '../../'))
+        return os.path.realpath(os.path.join(os.path.abspath(__file__), '../../'))
 
-    @staticmethod
-    def instruments():
-        return os.path.join(ChimeraPath.root(), 'instruments')
+    @property
+    def instruments(self):
+        return self._instruments
 
-    @staticmethod
-    def controllers():
-        return os.path.join(ChimeraPath.root(), 'controllers')
+    @property
+    def controllers(self):
+        return self._controllers

--- a/src/chimera/util/findplugins.py
+++ b/src/chimera/util/findplugins.py
@@ -1,0 +1,22 @@
+import os
+from pkgutil import iter_modules
+
+
+def find_chimera_plugins(prefix='chimera_'):
+    """
+    Returns chimera plugins paths for instruments and controllers.
+
+    :param prefix: Prefix of the plugins package names.
+    """
+
+    instruments_path = []
+    controllers_path = []
+    for i in iter_modules():
+        if i[1].startswith(prefix):
+            fname = i[0].find_module(i[1]).filename
+            if os.path.isdir('%s/controllers' % fname):
+                controllers_path.append('%s/controllers' % fname)
+            if os.path.isdir('%s/instruments' % fname):
+                instruments_path.append('%s/instruments' % fname)
+
+    return controllers_path, instruments_path

--- a/src/scripts/chimera-admin
+++ b/src/scripts/chimera-admin
@@ -72,8 +72,9 @@ class doStuff:
                       "controllers": []}
 
         # add system path
-        self.paths["instruments"].append(ChimeraPath.instruments())
-        self.paths["controllers"].append(ChimeraPath.controllers())
+        cp = ChimeraPath()
+        self.paths["instruments"].expand(cp.instruments)
+        self.paths["controllers"].expand(cp.controllers)
 
         log.info(
             "Setting objects include path from command line parameters...")


### PR DESCRIPTION
Makes chimera look for instruments and controllers in all python modules which name starts with ``chimera_``. A template example can be found on the link below. Fixes #56.

https://github.com/astroufsc/chimera_template