### PR TITLE
Camera fits headers and config adjustments

### DIFF
--- a/src/chimera/controllers/autofocus.py
+++ b/src/chimera/controllers/autofocus.py
@@ -404,7 +404,10 @@ class Autofocus(ChimeraObject, IAutofocus):
         config['PIXEL_SCALE'] = 0  # use WCS info
         config['BACK_TYPE'] = "AUTO"
 
-        config['SATUR_LEVEL'] = self.getCam()["ccd_saturation_level"]
+        try:
+            config['SATUR_LEVEL'] = self.getCam()["ccd_saturation_level"]
+        except KeyError:
+            pass  # If there is no ccd_saturation_level on the config, it will use the default saturation level
 
         # improve speed with higher threshold
         config['DETECT_THRESH'] = 3.0

--- a/src/chimera/instruments/camera.py
+++ b/src/chimera/instruments/camera.py
@@ -191,7 +191,7 @@ class CameraBase (ChimeraObject,
                 ("CD2_1", 0.0, "transformation matrix element (2,1)"),
                 ("CD2_2", scale_y, "transformation matrix element (2,2)"),
 
-                ('CAMERA', str(self['camera_model']), 'Camera Model'),
+                ('INSTRUME', str(self['camera_model']), 'Name of instrument'),
                 ('CCD',    str(self['ccd_model']), 'CCD Model'),
                 ('CCD_DIMX', self.getPhysicalSize()
                  [0], 'CCD X Dimension Size'),

--- a/src/chimera/interfaces/camera.py
+++ b/src/chimera/interfaces/camera.py
@@ -104,15 +104,15 @@ class Camera (Interface):
     """
 
     # config
-    __config__ = {"device": "USB",
-                  "ccd": CCD.IMAGING,
-                  "temp_delta": 2.0,
+    __config__ = {"device": None,
+                  "ccd": None,
+                  "temp_delta": None,
 
-                  "ccd_saturation_level": 60000,
+                  "ccd_saturation_level": None,
 
-                  "camera_model": "Fake camera Inc.",
-                  "ccd_model": "KAF XYZ 10",
-                  "telescope_focal_length": 4000  # milimeter
+                  "camera_model": "Unknown",
+                  "ccd_model": "Unknown",
+                  "telescope_focal_length": None  # milimeter
                   }
 
 

--- a/src/chimera/interfaces/camera.py
+++ b/src/chimera/interfaces/camera.py
@@ -104,15 +104,11 @@ class Camera (Interface):
     """
 
     # config
-    __config__ = {"device": None,
-                  "ccd": None,
-                  "temp_delta": None,
-
-                  "ccd_saturation_level": None,
+    __config__ = {"device": "Unknown",
+                  "ccd": CCD.IMAGING,
 
                   "camera_model": "Unknown",
                   "ccd_model": "Unknown",
-                  "telescope_focal_length": None  # milimeter
                   }
 
 

--- a/src/chimera/interfaces/filterwheel.py
+++ b/src/chimera/interfaces/filterwheel.py
@@ -36,9 +36,9 @@ class FilterWheel(Interface):
     Allow simple control and monitor filter changes    
     """
 
-    __config__ = {"device": "/dev/ttyS0",
-                  "filter_wheel_model": "Fake Filters Inc.",
-                  "filters": "R G B LUNAR CLEAR"  # space separated
+    __config__ = {"device": "Unknown",
+                  "filter_wheel_model": "Unknown",
+                  "filters": "A B C"  # space separated
                   # filter names (in position
                                                   # order)
                   }

--- a/src/chimera/util/image.py
+++ b/src/chimera/util/image.py
@@ -173,7 +173,7 @@ class Image (DictMixin, RemoteObject):
         hdu = fits.PrimaryHDU(data)
 
         headers = [("DATE", ImageUtil.formatDate(dt.datetime.utcnow()), "date of file creation"),
-                   ("CREATOR", _chimera_name_, _chimera_long_description_)]
+                   ("AUTHOR", _chimera_name_, _chimera_long_description_)]
 
         # TODO: Implement BITPIX support
         hdu.scale('int16', '', bzero=32768, bscale=1)


### PR DESCRIPTION
This PR changes two things that are correlated:

1) It fixes few fits keywords to the standard keywords defined on http://heasarc.gsfc.nasa.gov/docs/fcg/standard_dict.html. The header keywords which were renamed are: CAMERA to INSTRUME and CREATOR to AUTHOR

2) Changes the defaults of configuration parameters that are strings to "Unknown" and removes the default for `telescope_focal_length` and `ccd_saturation_level` which could lead to a wrong WCS on the image file or problems on doing autofocus.
