### PR TITLE
Add focus temperature to the image headers

### DIFF
--- a/src/chimera/instruments/focuser.py
+++ b/src/chimera/instruments/focuser.py
@@ -51,6 +51,9 @@ class FocuserBase (ChimeraObject, Focuser):
     def getRange(self):
         raise NotImplementedError()
 
+    def getTemperature(self):
+        raise NotImplementedError()
+
     def supports(self, feature=None):
         if feature in self._supports:
             return self._supports[feature]
@@ -59,6 +62,11 @@ class FocuserBase (ChimeraObject, Focuser):
             return False
 
     def getMetadata(self, request):
-        return [('FOCUSER', str(self['model']), 'Focuser Model'),
-                ('FOCUS',  self.getPosition(),
-                 'Focuser position used for this observation')]
+        md = [('FOCUSER', str(self['model']), 'Focuser Model'),
+              ('FOCUS', self.getPosition(), 'Focuser position used for this observation')]
+        try:
+            md += [('FOCUSTEM', self.getTemperature(), 'Focuser Temperature at Exposure End [deg. C]')]
+        except NotImplementedError:
+            pass
+
+        return md


### PR DESCRIPTION
This PR simply adds the focuser temperature information to the image headers via the getMetadata() method on instruments.focuser.