### PR TITLE
Fix issue #80.

### DIFF
--- a/src/chimera/util/image.py
+++ b/src/chimera/util/image.py
@@ -344,6 +344,8 @@ class Image (DictMixin, RemoteObject):
 
         # ok, here we go!
         try:
+            if not os.path.exists(self._filename):
+                self.save(self._filename)
             sex.run(self._filename, clean=False)
             result = sex.catalog()
             return result


### PR DESCRIPTION
In some rare occasions the *extract* function of the Image class will fail with "*Error*: cannot open [filename]". This adds a check for the file to exists before running sextractor. If the file does not exists it will write it to disc.