### PR TITLE
Fixes image saving behaviour

### DIFF
--- a/src/chimera/controllers/imageserver/imagerequest.py
+++ b/src/chimera/controllers/imageserver/imagerequest.py
@@ -13,7 +13,7 @@ class ImageRequest (dict):
                   'interval', 'shutter',
                   'binning', 'window',
                   'bitpix', 'filename',
-                  'compress', 'compress_format',
+                  'compress_format',
                   'type', 'wait_dome',
                   'object_name']
 
@@ -27,7 +27,6 @@ class ImageRequest (dict):
                     'window': None,
                     'bitpix': Bitpix.uint16,
                     'filename': '$DATE-$TIME',
-                    'compress': False,
                     'compress_format': "NO",
                     'type': 'object',
                     'wait_dome': True,

--- a/src/chimera/controllers/imageserver/imagerequest.py
+++ b/src/chimera/controllers/imageserver/imagerequest.py
@@ -27,8 +27,8 @@ class ImageRequest (dict):
                     'window': None,
                     'bitpix': Bitpix.uint16,
                     'filename': '$DATE-$TIME',
-                    'compress': True,
-                    'compress_format': "BZ2",
+                    'compress': False,
+                    'compress_format': "NO",
                     'type': 'object',
                     'wait_dome': True,
                     'object_name': ''}

--- a/src/chimera/instruments/camera.py
+++ b/src/chimera/instruments/camera.py
@@ -156,7 +156,6 @@ class CameraBase (ChimeraObject,
 
         pix_w, pix_h = self.getPixelSize()
 
-        t0 = time.time()
         img = Image.create(imageData, imageRequest)
 
         try:
@@ -211,8 +210,9 @@ class CameraBase (ChimeraObject,
         server = getImageServer(self.getManager())
         proxy = server.register(img)
 
-        # and finally compress the image
-        img.compress(multiprocess=True)
+        # and finally compress the image if asked
+        if imageRequest['compress']:
+            img.compress(format=imageRequest['compress_format'], multiprocess=True)
 
         return proxy
 
@@ -280,7 +280,7 @@ class CameraBase (ChimeraObject,
             binning = self.getBinnings().keys().pop(
                 self.getBinnings().keys().index("1x1"))
 
-        return (mode, binning, top, left, width, height)
+        return mode, binning, top, left, width, height
 
     def isExposing(self):
         return self.__isExposing.isSet()

--- a/src/chimera/instruments/camera.py
+++ b/src/chimera/instruments/camera.py
@@ -211,7 +211,7 @@ class CameraBase (ChimeraObject,
         proxy = server.register(img)
 
         # and finally compress the image if asked
-        if imageRequest['compress']:
+        if imageRequest['compress_format'].lower() != 'no':
             img.compress(format=imageRequest['compress_format'], multiprocess=True)
 
         return proxy

--- a/src/chimera/util/image.py
+++ b/src/chimera/util/image.py
@@ -215,8 +215,8 @@ class Image (DictMixin, RemoteObject):
     def compressedFilename(self):
         if os.path.exists(self._filename + ".bz2"):
             return self._filename + ".bz2"
-        elif os.path.exists(self._filename + ".gzip"):
-            return self._filename + ".gzip"
+        elif os.path.exists(self._filename + ".gz"):
+            return self._filename + ".gz"
         elif os.path.exists(self._filename + ".zip"):
             return self._filename + ".zip"
         else:

--- a/src/chimera/util/image.py
+++ b/src/chimera/util/image.py
@@ -212,15 +212,6 @@ class Image (DictMixin, RemoteObject):
     def close(self):
         self._fd.close()
 
-    def compressedFilename(self):
-        if os.path.exists(self._filename + ".bz2"):
-            return self._filename + ".bz2"
-        elif os.path.exists(self._filename + ".gz"):
-            return self._filename + ".gz"
-        elif os.path.exists(self._filename + ".zip"):
-            return self._filename + ".zip"
-        else:
-            return self._filename
 
     def http(self, http=None):
         if http:

--- a/src/scripts/chimera-cam
+++ b/src/scripts/chimera-cam
@@ -40,6 +40,16 @@ currentFrameExposeStart = 0
 currentFrameReadoutStart = 0
 
 
+def get_compressed_name(filename, compression):
+    if compression.lower() == 'no':
+        return filename
+    if compression.lower() == 'bz2':
+        return filename+'.bz2'
+    if compression.lower() == 'gzip':
+        return filename+'.gz'
+    if compression.lower() == 'zip':
+        return filename+'.zip'
+
 class ChimeraCam (ChimeraCLI):
 
     def __init__(self):
@@ -462,7 +472,7 @@ class ChimeraCam (ChimeraCLI):
                 self.out("OK (took %.3f s)" %
                          (time.time() - currentFrameExposeStart))
 
-                self.out(" (%s) " % image.compressedFilename(), end="")
+                self.out(" (%s) " % get_compressed_name(image.filename(), compress_format), end="")
                 self.out("OK (took %.3f s)" %
                          (time.time() - currentFrameReadoutStart))
                 self.out("[%03d/%03d] took %.3fs" % (currentFrame, options.frames,

--- a/src/scripts/chimera-cam
+++ b/src/scripts/chimera-cam
@@ -422,10 +422,6 @@ class ChimeraCam (ChimeraCLI):
                 expTimes.extend(exps)
 
         compress_format = options.compress
-        if compress_format.lower() != "no":
-            compress = True
-        else:
-            compress = False
 
         # DS9
         ds9 = None
@@ -561,7 +557,6 @@ class ChimeraCam (ChimeraCLI):
                                       binning=options.binning or None,
                                       window=options.subframe or None,
                                       shutter=options.shutter,
-                                      compress=compress,
                                       compress_format=compress_format,
                                       wait_dome=not options.ignore_dome,
                                       object_name=object_name)
@@ -575,7 +570,6 @@ class ChimeraCam (ChimeraCLI):
                                   binning=options.binning or None,
                                   window=options.subframe or None,
                                   shutter=options.shutter,
-                                  compress=compress,
                                   compress_format=compress_format,
                                   wait_dome=not options.ignore_dome,
                                   object_name=object_name)


### PR DESCRIPTION
After astroufsc/chimera#40 some controllers started to not work because of the lack of the  `.fits` file. This is due two reasons:

* The default `ImageRequest` compress parameters are defined to be `True` and `bz2`,  compressing images always by default.

* On the camera instrument, it always compress the files using bzip2, no matter if `compress` is set to `False` or `compress_format` is not `bz2` on the `ImageRequest`.

This PR fixes this behavior by adding sane defaults and fixing camera instrument.