### PR TITLE
Fix #90

### DIFF
--- a/src/chimera/controllers/autofocus.py
+++ b/src/chimera/controllers/autofocus.py
@@ -404,10 +404,10 @@ class Autofocus(ChimeraObject, IAutofocus):
         config['PIXEL_SCALE'] = 0  # use WCS info
         config['BACK_TYPE'] = "AUTO"
 
-        try:
-            config['SATUR_LEVEL'] = self.getCam()["ccd_saturation_level"]
-        except KeyError:
-            pass  # If there is no ccd_saturation_level on the config, it will use the default saturation level
+        # CCD saturation level in ADUs.
+        s = self.getCam()["ccd_saturation_level"]
+        if s is not None:  # If there is no ccd_saturation_level on the config, use the default.
+            config['SATUR_LEVEL'] = s
 
         # improve speed with higher threshold
         config['DETECT_THRESH'] = 3.0

--- a/src/chimera/core/config.py
+++ b/src/chimera/core/config.py
@@ -21,7 +21,8 @@
 
 
 from types import (IntType, FloatType, StringType, LongType,
-                   DictType, TupleType, ListType, BooleanType)
+                   DictType, TupleType, ListType, BooleanType,
+                   NoneType)
 
 try:
     import cPickle as pickle
@@ -147,6 +148,16 @@ class StringChecker (Checker):
         # simple case (nearly everything can be converted to str, just cross
         # fingers and convert!)
         return str(value)
+
+
+class NoneChecker (Checker):
+
+    def __init__(self):
+        Checker.__init__(self)
+
+    def check(self, value):
+        # Just return the None value.
+        return value
 
 
 class BoolChecker (Checker):
@@ -398,6 +409,10 @@ class Config (object):
                 options[name] = Option(name, value, BoolChecker())
                 continue
 
+            if isinstance(value, NoneType):
+                options[name] = Option(name, value, NoneChecker())
+                continue
+
             # FIXME: for list and tuple we use the first element as default option
             #        there is no way to specify other default for this types
             if type(value) == ListType:
@@ -420,8 +435,7 @@ class Config (object):
                 continue
 
             if isinstance(value, Position):
-                options[name] = PositionOption(
-                    name, value, PositionChecker(value))
+                options[name] = PositionOption(name, value, PositionChecker(value))
                 continue
 
             raise ValueError("Invalid option type: %s." % type(value))

--- a/src/chimera/core/tests/test_config.py
+++ b/src/chimera/core/tests/test_config.py
@@ -65,7 +65,8 @@ class TestConfig (object):
         c = Config({"key_opt_int": [1, 2, 3],
                     "key_opt_float": [1, 2.0, 4.0],
                     "key_opt_bool": [1, False],
-                    "key_opt_str": ["one", "two", "three"]})
+                    "key_opt_str": ["one", "two", "three"],
+                    "key_opt_none": [None, None, None]})
 
         # valid
         for i in (1, 2, 3, True): # True == 1
@@ -113,7 +114,8 @@ class TestConfig (object):
              "save_on_temp" : False,
              "seq_num"      : 1,
              "observer"     : "observer name",
-             "obj_name"     : "object name"}
+             "obj_name"     : "object name",
+             "some_none_var": None}
 
         c = Config(d)
 

--- a/src/chimera/instruments/camera.py
+++ b/src/chimera/instruments/camera.py
@@ -159,7 +159,7 @@ class CameraBase (ChimeraObject,
         t0 = time.time()
         img = Image.create(imageData, imageRequest)
 
-        try:
+        if self["telescope_focal_length"] is not None:  # If there is no telescope_focal_length defined, don't store WCS
             focal_length = self["telescope_focal_length"]
 
             scale_x = binFactor * (((180 / pi) / focal_length) * (pix_w * 0.001))
@@ -175,9 +175,6 @@ class CameraBase (ChimeraObject,
                 ("CD1_2", 0.0, "transformation matrix element (1,2)"),
                 ("CD2_1", 0.0, "transformation matrix element (2,1)"),
                 ("CD2_2", scale_y, "transformation matrix element (2,2)")]
-
-        except KeyError:  # If there is no telescope_focal_length defined, don't store WCS
-            pass
 
         img += [('DATE-OBS',
                  ImageUtil.formatDate(

--- a/src/chimera/interfaces/camera.py
+++ b/src/chimera/interfaces/camera.py
@@ -107,7 +107,9 @@ class Camera (Interface):
                   "ccd": CCD.IMAGING,             # CCD to be used when multiple ccd camera. IMAGING or TRACKING.
                   "camera_model": "Unknown",      # Camera model string. To be used by metadata purposes
                   "ccd_model": "Unknown",         # CCD model string. To be used by metadata purposes
-                  "ccd_saturation_level": None,   # CCD level at which arises saturation (in ADUs)
+                  "ccd_saturation_level": None,   # CCD level at which arises saturation (in ADUs).
+                                                  # Needed by SExtractor when doing auto-focus, autoguiding...
+
                   # WCS configuration parameters  #
                   "telescope_focal_length": None, # Telescope focal length (in millimeters)
                   "rotation": 0.                  # Angle between the North and the second axis of the image counted

--- a/src/chimera/interfaces/camera.py
+++ b/src/chimera/interfaces/camera.py
@@ -103,12 +103,12 @@ class Camera (Interface):
     Base camera interface.
     """
 
-    # config
-    __config__ = {"device": "Unknown",
-                  "ccd": CCD.IMAGING,
-
-                  "camera_model": "Unknown",
-                  "ccd_model": "Unknown",
+    __config__ = {"device": "Unknown",            # Bus address identifier for this camera. E.g. USB, LPT1, ...
+                  "ccd": CCD.IMAGING,             # CCD to be used when multiple ccd camera. IMAGING or TRACKING.
+                  "camera_model": "Unknown",      # Camera model string. To be used by metadata purposes
+                  "ccd_model": "Unknown",         # CCD model string. To be used by metadata purposes
+                  "ccd_saturation_level": None,   # CCD level at which arises saturation (in ADUs)
+                  "telescope_focal_length": None  # Telescope focal length (in millimeters)
                   }
 
 

--- a/src/chimera/interfaces/camera.py
+++ b/src/chimera/interfaces/camera.py
@@ -108,8 +108,10 @@ class Camera (Interface):
                   "camera_model": "Unknown",      # Camera model string. To be used by metadata purposes
                   "ccd_model": "Unknown",         # CCD model string. To be used by metadata purposes
                   "ccd_saturation_level": None,   # CCD level at which arises saturation (in ADUs)
+                  # WCS configuration parameters  #
                   "telescope_focal_length": None, # Telescope focal length (in millimeters)
-                  "rotation": 0.
+                  "rotation": 0.                  # Angle between the North and the second axis of the image counted
+                                                  # positive to the East (in degrees)
                   }
 
 


### PR DESCRIPTION
This PR fixes the bug related on #90 by:

* Added NoneType variables support to the configuration file;

* Re-added missing configuration parameters with default value set to `None`;

* Fixed how the `None` is treated where needed.

I have tested this using a chimera.config with and without the `telescope_focal_length` option on the camera, and it works as expected: grabs the WCS on the header of the image only when present.