### PR TITLE
Fix issue 94

### DIFF
--- a/src/chimera/controllers/imageserver/imageserverhttp.py
+++ b/src/chimera/controllers/imageserver/imageserverhttp.py
@@ -33,7 +33,7 @@ class ImageServerHTTPHandler(SimpleHTTPRequestHandler):
         self.wfile.write(txt)
 
     def response_file(self, filename, ctype):
-        f = open(filename)
+        f = open(filename,'rb')
         if not f:
             self.response(404, "Couldn't find")
         else:


### PR DESCRIPTION
This PR provides a fix for issue #94 where, in some platforms, opening the fits file for reading only would cause problems with the image transfer, apparently due to the interpretation of EOL and EOF. Opening the file for reading in binary mode fix this issue.