### PR TITLE
Listen on ALL interfaces when host is 0.0.0.0

### DIFF
--- a/src/chimera/core/manager.py
+++ b/src/chimera/core/manager.py
@@ -69,10 +69,7 @@ class ManagerAdapter (Pyro.core.Daemon):
         Pyro.core.initServer(banner=False)
 
         try:
-            Pyro.core.Daemon.__init__(self,
-                                      host=host or MANAGER_DEFAULT_HOST,
-                                      port=port or MANAGER_DEFAULT_PORT,
-                                      norange=0)
+            Pyro.core.Daemon.__init__(self, host=host, port=port, norange=0)
         except Pyro.errors.DaemonError:
             log.error("Couldn't start Chimera server. Check errors below.")
             raise
@@ -304,7 +301,7 @@ class Manager (RemoteObject):
             return (location.port == None or location.port == self.getPort())
         else:
             return (location.host == None or location.host in (meHost, meName)) and \
-                   (location.port == None or location.port == self.getPort())
+                   (location.port == None or location.port == mePort)
 
     # shutdown management
 

--- a/src/chimera/core/systemconfig.py
+++ b/src/chimera/core/systemconfig.py
@@ -176,6 +176,11 @@ class SystemConfig (object):
         # parse chimera section first, to get host/port or set defaults
         for type, values in config.items():
             if type.lower() == "chimera":
+                try:
+                    if values["host"] == "0.0.0.0":
+                        values["host"] = None
+                except KeyError:
+                    pass
                 self.chimera.update(values)
                 # BIGGG FIXME: read all files before create Locations,
                 # to avoid this hack


### PR DESCRIPTION
This PR fixes #100 by changing the host to `None` when the `host: 0.0.0.0` is set on the `chimera` sction of the configuration file.