### PR TITLE
Telescope cover minor fixes

### DIFF
--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -200,15 +200,11 @@ class TelescopeBase(ChimeraObject,
         '''
         raise NotImplementedError()
 
-    def isParked(self):
+    def isCoverOpen(self):
+        '''
+        Tells if cover is open or not.
+        '''
         raise NotImplementedError()
-
-    @lock
-    def setParkPosition(self, position):
-        self._park_position = position
-
-    def getParkPosition(self):
-        return self._park_position or self["default_park_position"]
 
     def startTracking(self):
         raise NotImplementedError()

--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -176,6 +176,16 @@ class TelescopeBase(ChimeraObject,
     def unpark(self):
         raise NotImplementedError()
 
+    def isParked(self):
+        raise NotImplementedError()
+
+    @lock
+    def setParkPosition(self, position):
+        self._park_position = position
+
+    def getParkPosition(self):
+        return self._park_position or self["default_park_position"]
+
     @lock
     def openCover(self):
         '''

--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -24,7 +24,7 @@ from chimera.core.chimeraobject import ChimeraObject
 
 from chimera.interfaces.telescope import (TelescopeSlew, TelescopeSync,
                                           TelescopePark, TelescopeTracking,
-                                          SlewRate)
+                                          SlewRate, TelescopeCover)
 
 from chimera.core.lock import lock
 from chimera.core.exceptions import ObjectTooLowException
@@ -38,7 +38,8 @@ __all__ = ["TelescopeBase"]
 
 class TelescopeBase(ChimeraObject,
                     TelescopeSlew, TelescopeSync,
-                    TelescopePark, TelescopeTracking):
+                    TelescopePark, TelescopeTracking,
+                    TelescopeCover):
 
     def __init__(self):
         ChimeraObject.__init__(self)

--- a/src/chimera/interfaces/telescope.py
+++ b/src/chimera/interfaces/telescope.py
@@ -417,6 +417,12 @@ class TelescopePark (Telescope):
         successfully.
         """
 
+class TelescopeCover(Telescope):
+    """
+    Telescope with mirror cover.
+    """
+
+
     def openCover(self):
         """
         Open the telescope cover

--- a/src/chimera/interfaces/telescope.py
+++ b/src/chimera/interfaces/telescope.py
@@ -417,6 +417,28 @@ class TelescopePark (Telescope):
         successfully.
         """
 
+    def openCover(self):
+        """
+        Open the telescope cover
+
+        :return: None
+        """
+
+    def closeCover(self):
+        """
+        Close the telescope cover
+
+        @:return: None
+        """
+
+    def isCoverOpen(self):
+        """
+        Ask if the telescope cover is open or not
+
+        @:return: True if cover is open, false otherwise
+        """
+
+
 
 class TelescopeTracking (Telescope):
 

--- a/src/scripts/chimera-tel
+++ b/src/scripts/chimera-tel
@@ -265,6 +265,14 @@ class ChimeraTel (ChimeraCLI):
         else:
             self.out("tracking: disabled.")
 
+        try:
+            if telescope.isCoverOpen():
+                self.out("cover: open.")
+            else:
+                self.out("cover: closed.")
+        except NotImplementedError:
+            pass
+
         self.out(40 * "=")
 
     def _move(self, direction, cmd, offset):


### PR DESCRIPTION
* Added missing isCoverOpen() method
* Added telescope cover methods to the interface. They were only on the instrument
* If there is a isCoverOpen() method, `chimera-tel --info` will tell about it