### PR TITLE
Change chimera-cam behavior on downloading remote images.

### DIFF
--- a/src/scripts/chimera-cam
+++ b/src/scripts/chimera-cam
@@ -28,9 +28,12 @@ from chimera.core.compat import freeze_support
 from chimera.interfaces.filterwheel import InvalidFilterPositionException
 from chimera.interfaces.camera import CameraFeature, CameraStatus
 
+from chimera.controllers.imageserver.util import getImageServer
+from chimera.util.image import ImageUtil,Image
+
 from chimera.util.ds9 import DS9
 
-import sys
+import sys, os, ntpath
 import time
 #import threading
 import copy
@@ -479,6 +482,12 @@ class ChimeraCam (ChimeraCLI):
                                                      time.time() - currentFrameExposeStart))
 
                 if ds9:
+                    # If file does not exists (as in remote cameras), try downloading it. Note that it will be
+                    # downloaded anyway by ds9 when trying to display it. But, if we do it here, we can take
+                    # advantage of the local file to do some analysis (like with IRAF).
+                    if not os.path.exists(image.filename()):
+                        image = self._downloadImage(image)
+
                     ds9.set("scale mode 99.5")
                     ds9.displayImage(image)
 
@@ -597,6 +606,21 @@ class ChimeraCam (ChimeraCLI):
             self.out("%s" % time.strftime("%c"))
             self.out(40 * "=")
 
+
+    def _downloadImage(self,image):
+
+        image_path = image.filename()
+
+        #  If remote is windows, image_path will be c:\...\image.fits, so use ntpath instead of os.path.
+        if ':\\' in image_path:
+            modpath = ntpath
+        else:
+            modpath = os.path
+        image_path = ImageUtil.makeFilename(os.path.join(getImageServer(self.getManager()).defaultNightDir(),
+                                                         modpath.basename(image_path)))
+        image.close() # Close image here
+
+        return Image.fromFile(image_path)
 
 def main():
     cli = ChimeraCam()


### PR DESCRIPTION
An update on chimera-cam to download the image when using a remote camera and displaying it. The problem with the current strategy, where chimera-cam leaves the hard work for the "ds9" interface, is that you end up downloading the image anyway but you cannot operate on it outside ds9. For instance, if you want to analyse the image with iraf you end up having to download the image again. 
