### PR TITLE
Add autoguider action on chimera scheduler controller.

### DIFF
--- a/src/chimera/controllers/scheduler/controller.py
+++ b/src/chimera/controllers/scheduler/controller.py
@@ -27,6 +27,7 @@ class Scheduler(ChimeraObject):
                   "dome": "/Dome/0",
                   "autofocus": "/Autofocus/0",
                   "point_verify": "/PointVerify/0",
+                  "autoguider": "/AutoGuider/0",
                   'site': '/Site/0',
                   'algorithm': SchedulingAlgorithm.SEQUENTIAL}
 

--- a/src/chimera/controllers/scheduler/executor.py
+++ b/src/chimera/controllers/scheduler/executor.py
@@ -1,7 +1,7 @@
 
 from chimera.controllers.scheduler.handlers import (ExposeHandler, PointHandler,
-                                                    AutoFocusHandler, PointVerifyHandler)
-from chimera.controllers.scheduler.model import Expose, Point, AutoFocus, PointVerify
+                                                    AutoFocusHandler, PointVerifyHandler, AutoGuiderHandler)
+from chimera.controllers.scheduler.model import Expose, Point, AutoFocus, PointVerify, AutoGuide
 from chimera.controllers.scheduler.handlers import ActionHandler
 from chimera.controllers.scheduler.status import SchedulerStatus
 
@@ -27,7 +27,9 @@ class ProgramExecutor(object):
         self.actionHandlers = {Expose     : ExposeHandler,
                                Point      : PointHandler,
                                AutoFocus  : AutoFocusHandler,
-                               PointVerify: PointVerifyHandler}
+                               PointVerify: PointVerifyHandler,
+                               AutoGuide  : AutoGuiderHandler,
+                               }
 
     def __start__ (self):
         for handler in self.actionHandlers.values():

--- a/src/chimera/controllers/scheduler/handlers.py
+++ b/src/chimera/controllers/scheduler/handlers.py
@@ -159,3 +159,43 @@ class PointVerifyHandler(ActionHandler):
         pass
         
 
+class AutoGuiderHandler(ActionHandler):
+
+    @staticmethod
+    @requires("autoguider")
+    def process(action):
+
+        if action.stop:
+            AutoGuiderHandler.abort(action)
+        else:
+            guiding = False
+            ag = AutoGuiderHandler.autoguider
+
+            for iter in range(action.ntries):
+                try:
+                    ag.guide(exptime=action.min_exptime+iter*action.max_exptime/action.ntries,
+                             filter=action.filter,
+                             binning=action.binning,
+                             windowCCD=action.windowCCD,
+                             box=action.box)
+                except Exception, e:
+                    pass
+                else:
+                    guiding = True
+                    break
+
+        if not guiding:
+            raise ProgramExecutionException("Could not start guider.")
+
+    @staticmethod
+    def abort(action):
+        ag = copy.copy(AutoGuiderHandler.autoguider)
+        ag.stop()
+
+    @staticmethod
+    def log(action):
+        if action.stop:
+            return "autoguider: stop"
+        else:
+            return "autoguider: start"
+

--- a/src/chimera/controllers/scheduler/model.py
+++ b/src/chimera/controllers/scheduler/model.py
@@ -86,7 +86,36 @@ class AutoFocus(Action):
 
     def __str__ (self):
         return "autofocus: start=%d end=%d step=%d exptime=%d" % (self.start, self.end, self.step, self.exptime)
-    
+
+class AutoGuide(Action):
+    __tablename__ = "action_ag"
+    __mapper_args__ = {'polymorphic_identity': 'AutoGuide'}
+
+    id             = Column(Integer, ForeignKey('action.id'), primary_key=True)
+
+    min_exptime    = Column(Float,   default= 1.)
+    max_exptime    = Column(Float,   default=10.)
+    ntries         = Column(Integer, default= 3 )
+
+    filter     = Column(String,  default=None)
+    binning    = Column(String, default=None)
+    windowCCD  = Column(Boolean, default=True)
+    box        = Column(Integer, default=None)
+
+    stop       = Column(Boolean, default=False) # Add an action with stop = True at the end of each observing sequence
+
+    def __str__ (self):
+        if self.stop:
+            return "AutoGuide: End a running autoguider instance."
+        else:
+            return "AutoGuide: exptime=[%f:%f] ntries=%i filter=%s binning=%s windowCCD=%s box=%s"%(self.min_exptime,
+                                                                                                    self.max_exptime,
+                                                                                                    self.ntries,
+                                                                                                    self.filter,
+                                                                                                    self.binning,
+                                                                                                    self.windowCCD,
+                                                                                                   'auto' if self.box is None else self.box)
+
 class PointVerify(Action):
     __tablename__ = "action_pv"
     __mapper_args__ = {'polymorphic_identity': 'PointVerify'}

--- a/src/scripts/chimera-sched
+++ b/src/scripts/chimera-sched
@@ -28,7 +28,8 @@ from chimera.util.output import blue, green, red
 from chimera.controllers.scheduler.status import SchedulerStatus
 from chimera.controllers.scheduler.states import State
 from chimera.controllers.scheduler.model import (Session, Program, Point,
-                                                 Expose, PointVerify, AutoFocus)
+                                                 Expose, PointVerify, AutoFocus,
+                                                 AutoGuide)
 
 import re
 import sys
@@ -55,6 +56,23 @@ class ChimeraSched (ChimeraCLI):
         # RA      dec       epoch  type    name  N*(f1:t1:n1, f2:t2:n2, ......)
         14:00:00 -30:00:00  J2000  OBJECT  obj1  2*(V:7, R:6:2, B:5:2)
         15:00:00 -30:00:00  NOW    OBJECT  obj2  2*(V:7, R:6:2, B:5:2)
+
+        # To use the auto-guider just add a new column after the exposure setup with the auto-guider options
+        # in parentheses.
+        #
+        # Parameters are:
+        #
+        # min_exptime - Minimum exposure time to try and find a guiding star
+        # max_exptime - Maximum exposure time to try and find a guiding star
+        # ntries      - Number or tries (will increase exposure time linearly)
+        # filter      - Filter to be used
+        # binning     - Binning of guider camera
+        # windowCCD   - Window guider frame on exposures?
+        # box         - Size of guiding box (in pixels). None for auto-setup.
+
+        # RA      dec       epoch  type    name N*(f1:t1:n1, f2:t2:n2, ......) auto-guider
+        14:00:00 -30:00:00  J2000  OBJECT  obj1 2*(V:7, R:6:2, B:5:2)          (0.5,10.,5,None,None,True,None)
+        15:00:00 -30:00:00  NOW    OBJECT  obj2 2*(V:7, R:6:2, B:5:2)          (  5,30.,5,None,None,True,None)
 
         # special targets follow different format
         # for bias and dark, filter is ignored, we use same format just to keep it simple
@@ -103,6 +121,7 @@ class ChimeraSched (ChimeraCLI):
         self.generateDatabase(options)
 
     def generateDatabase(self, options):
+
         f = None
         try:
             f = open(options.filename, "r")
@@ -112,7 +131,8 @@ class ChimeraSched (ChimeraCLI):
         session = Session()
 
         lineRe = re.compile('(?P<coord>(?P<ra>[\d:-]+)\s+(?P<dec>\+?[\d:-]+)\s+(?P<epoch>[\dnowNOWJjBb\.]+)\s+)?(?P<imagetype>[\w]+)'
-                            '\s+(?P<objname>\'([^\\n\'\\\\]|\\\\.)*\'|"([^\\n"\\\\]|\\\\.)*"|([^ \\n"\\\\]|\\\\.)*)\s+(?P<exposures>[\w\d\s:\*\(\),]*)')
+                            '\s+(?P<objname>\'([^\\n\'\\\\]|\\\\.)*\'|"([^\\n"\\\\]|\\\\.)*"|([^ \\n"\\\\]|\\\\.)*)\s+(?P<exposures>[\w\d\s:\*\(\),]*)'
+                            '\s+(?P<AG>[\w\d\s\*\(,\.\)]+)?')
         programs = []
 
         for i, line in enumerate(f):
@@ -140,6 +160,16 @@ class ChimeraSched (ChimeraCLI):
             imagetype = params['imagetype'].upper()
             objname = params['objname'].replace("\"", "")
 
+            autoguider = None
+
+            if params.get("AG",None):
+                autoguider = params['AG'].replace('(','').replace(')','').replace('\n','').split(',')
+                for i,typecheck in enumerate((float,float,int,str,str,bool,int)):
+                    try:
+                        autoguider[i] = typecheck(autoguider[i])
+                    except:
+                        autoguider[i] = None
+
             multiplier, exps = params['exposures'].split("*")
             try:
                 multiplier = int(multiplier)
@@ -155,13 +185,22 @@ class ChimeraSched (ChimeraCLI):
 
                 self.out("# program: %s" % program.name)
 
-                if imagetype == "OBJECT":
+                if imagetype == "OBJECT" and i == 0:
                     if position:
                         program.actions.append(Point(targetRaDec=position))
                     else:
                         program.actions.append(Point(targetName=objname))
 
-                if imagetype == "FLAT":
+                    if autoguider is not None:
+                        program.actions.append(AutoGuide(min_exptime=autoguider[0],
+                                                         max_exptime=autoguider[1],
+                                                         ntries     =autoguider[2],
+                                                         filter     =autoguider[3],
+                                                         binning    =autoguider[4],
+                                                         windowCCD  =autoguider[5],
+                                                         box        =autoguider[6]))
+
+                if imagetype == "FLAT" and i == 0:
                     site = self._remoteManager.getProxy("/Site/0")
                     flatPosition = Position.fromAltAz(
                         site['flat_alt'], site['flat_az'])
@@ -200,7 +239,17 @@ class ChimeraSched (ChimeraCLI):
                                                   exptime=exptime,
                                                   imageType=imagetype,
                                                   objectName=objname))
+
                 self.out("")
+                programs.append(program)
+
+            if autoguider is not None:
+
+                program = Program(
+                    name="%s-stop-autoguider" % (objname.replace(" ", "")))
+
+                program.actions.append(AutoGuide(stop=True))
+
                 programs.append(program)
 
         session.add_all(programs)


### PR DESCRIPTION
# On controller

Add ``autoguider`` to the configuration list.

# On executor 

Add ``actionHandlers``

# On handlers 

Add ``AutoGuideHandler``, a class to deal with the action. It has basically two modes of operation. If the flag ``action.stop`` is True it will issue an abort signal to the guider. Otherwise it will try to start a guider sequence. It is important to aways "stop" a guiding sequence before slewing the telescope.

# On model

Add ``AutoGuide``, a table to store the parameters required for guiding.

# On chimera-sched: 

When more than one repetition of an object was requested, like in 

> 14:00:00 -30:00:00  J2000  OBJECT  obj1  2*(V:7, R:6:2, B:5:2)

the scheduler was repeating the "pointing" operation. Changed so it will only point before the first sequence. 

Update regular expression on function ``generateDatabase`` so it will read an optional field at the end of the sequence with the guiding parameters between (). 

> 14:00:00 -30:00:00  J2000  OBJECT  obj1 2*(V:7, R:6:2, B:5:2)          (0.5,10.,5,None,None,True,None)

Update the function to include an "autoguide start" sequence after slew is complete and before the first acquisition and a "autoguide stop" after the last acquisition.  

Added a helper for the autoguider.