### PR TITLE
Add event to signal that telescope started/stopped tracking. 

### DIFF
--- a/src/chimera/interfaces/telescope.py
+++ b/src/chimera/interfaces/telescope.py
@@ -449,7 +449,7 @@ class TelescopeTracking (Telescope):
 
         """
     @event
-    def trackingStarted(self,position):
+    def trackingStarted(self, position):
         """
         Indicates that a tracking operation started.
 
@@ -458,7 +458,7 @@ class TelescopeTracking (Telescope):
         """
 
     @event
-    def trackingStopped(self,position, status):
+    def trackingStopped(self, position, status):
         """
         Indicates that the last tracking operation stopped. This event
         will be fired even when problems impedes tracking operation to resume

--- a/src/chimera/interfaces/telescope.py
+++ b/src/chimera/interfaces/telescope.py
@@ -448,3 +448,26 @@ class TelescopeTracking (Telescope):
         @rtype: bool
 
         """
+    @event
+    def trackingStarted(self,position):
+        """
+        Indicates that a tracking operation started.
+
+        @param position: The position where the telescope started track.
+        @type  position: L{Position}
+        """
+
+    @event
+    def trackingStopped(self,position, status):
+        """
+        Indicates that the last tracking operation stopped. This event
+        will be fired even when problems impedes tracking operation to resume
+        (altitude limits, for example). Check L{status} field if you
+        need more information.
+
+        @param position: The telescope position when tracking stopped.
+        @type  position: L{Position}
+
+        @param status: The status of the tracking operation.
+        @type  status: L{TelescopeStatus}
+        """


### PR DESCRIPTION
Updated FakeTelescope to use the new signaling events. Also, on FakeTelescope, added a ``startTracking`` after a ``slewToRaDec`` operation. 

All other external telescope drivers should be updated to include this.

This is actually a major requirement for various reasons, including safety. For instance, rigth now chimera is not aware in case the telescope reaches a low altitute limit as well as if there is any other problem which stops tracking.