### PR TITLE
Add dome flap to dome. 

### DIFF
--- a/src/chimera/instruments/dome.py
+++ b/src/chimera/instruments/dome.py
@@ -24,7 +24,7 @@ import Queue
 import threading
 
 from chimera.core.chimeraobject import ChimeraObject
-from chimera.interfaces.dome import Mode, DomeSlew, DomeSlit, DomeLights, DomeSync
+from chimera.interfaces.dome import Mode, DomeSlew, DomeSlit, DomeFlap, DomeLights, DomeSync
 from chimera.core.lock import lock
 from chimera.core.exceptions import ObjectNotFoundException
 from chimera.core.exceptions import ChimeraException
@@ -34,7 +34,7 @@ from chimera.util.coord import Coord
 __all__ = ['DomeBase']
 
 
-class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeLights, DomeSync):
+class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeLights, DomeSync):
     def __init__(self):
         ChimeraObject.__init__(self)
 
@@ -275,6 +275,17 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeLights, DomeSync):
         raise NotImplementedError()
 
     def isSlitOpen(self):
+        raise NotImplementedError()
+
+    @lock
+    def openFlap(self):
+        raise NotImplementedError()
+
+    @lock
+    def closeFlap(self):
+        raise NotImplementedError()
+
+    def isFlapOpen(self):
         raise NotImplementedError()
 
     def getMetadata(self, request):

--- a/src/chimera/instruments/fakedome.py
+++ b/src/chimera/instruments/fakedome.py
@@ -119,7 +119,7 @@ class FakeDome (DomeBase):
     def closeSlit(self):
         self.log.info("Closing slit")
         if self.isFlapOpen():
-            self.log.warning("Dome flap opened. Closing it before closing the slit.")
+            self.log.warning("Dome flap open. Closing it before closing the slit.")
             self.closeFlap()
         time.sleep(2)
         self._slitOpen = False

--- a/src/chimera/instruments/fakedome.py
+++ b/src/chimera/instruments/fakedome.py
@@ -37,6 +37,7 @@ class FakeDome (DomeBase):
         self._position = 0
         self._slewing = False
         self._slitOpen = False
+        self._flapOpen = False
         self._abort = threading.Event()
         self._maxSlewTime = 5 / 180.0
 
@@ -117,9 +118,31 @@ class FakeDome (DomeBase):
     @lock
     def closeSlit(self):
         self.log.info("Closing slit")
+        if self.isFlapOpen():
+            self.log.warning("Dome flap opened. Closing it before closing the slit.")
+            self.closeFlap()
         time.sleep(2)
         self._slitOpen = False
         self.slitClosed(self.getAz())
 
     def isSlitOpen(self):
         return self._slitOpen
+
+    @lock
+    def openFlap(self):
+        self.log.info("Opening flap")
+        if not self.isSlitOpen():
+            raise InvalidDomePositionException("Cannot open dome flap with slit closed.")
+        time.sleep(2)
+        self._flapOpen = True
+        self.flapOpened(self.getAz())
+
+    @lock
+    def closeFlap(self):
+        self.log.info("Closing flap")
+        time.sleep(2)
+        self._slitOpen = False
+        self.slitClosed(self.getAz())
+
+    def isFlapOpen(self):
+        return self._flapOpen

--- a/src/chimera/interfaces/dome.py
+++ b/src/chimera/interfaces/dome.py
@@ -195,7 +195,7 @@ class DomeFlap(Dome):
 
     def isFlapOpen(self):
         """
-        Ask the dome if the flap is opened.
+        Ask the dome if the flap is open.
 
         @return: True when open, False otherwise.
         @rtype: bool

--- a/src/chimera/interfaces/dome.py
+++ b/src/chimera/interfaces/dome.py
@@ -173,6 +173,52 @@ class DomeSlit(Dome):
         @type  az: Coord
         """
 
+class DomeFlap(Dome):
+    """
+    Dome with Slit
+    """
+
+    def openFlap(self):
+        """
+        Open the dome flap.
+
+        @rtype: None
+        """
+
+
+    def closeFlap(self):
+        """
+        Close the dome flap.
+
+        @rtype: None
+        """
+
+    def isFlapOpen(self):
+        """
+        Ask the dome if the flap is opened.
+
+        @return: True when open, False otherwise.
+        @rtype: bool
+        """
+
+
+    @event
+    def flapOpened(self, az):
+        """
+        Indicates that the flap was just opened
+
+        @param az: The azimuth when the flap opend
+        @type  az: Coord
+        """
+
+    @event
+    def flapClosed(self, az):
+        """
+        Indicates that the flap was just closed.
+
+        @param az: The azimuth when the flap closed.
+        @type  az: Coord
+        """
 
 class DomeLights(Dome):
     """"

--- a/src/scripts/chimera-dome
+++ b/src/scripts/chimera-dome
@@ -51,7 +51,7 @@ class ChimeraDome (ChimeraCLI):
         self.addHelpGroup("LIGHT", "Dome lights control")
 
     @action(help="Open dome slit", helpGroup="COMMANDS", actionGroup="SLIT")
-    def open(self, options):
+    def openSlit(self, options):
         self.out("Opening dome slit ... ", end="")
         self.dome.openSlit()
         self.out("OK")
@@ -59,9 +59,23 @@ class ChimeraDome (ChimeraCLI):
     @action(help="Close dome slit",
             helpGroup="COMMANDS",
             actionGroup="SLIT")
-    def close(self, options):
+    def closeSlit(self, options):
         self.out("Closing dome slit ... ", end="")
         self.dome.closeSlit()
+        self.out("OK")
+
+    @action(help="Open dome flap", helpGroup="COMMANDS", actionGroup="FLAP")
+    def openFlap(self, options):
+        self.out("Opening dome flap ... ", end="")
+        self.dome.openFlap()
+        self.out("OK")
+
+    @action(help="Close dome flap",
+            helpGroup="COMMANDS",
+            actionGroup="FLAP")
+    def closeFlap(self, options):
+        self.out("Closing dome flap ... ", end="")
+        self.dome.closeFlap()
         self.out("OK")
 
     @action(long="lights-off",


### PR DESCRIPTION
Updated interface, instrument and fakedome. 

On chimera-dome, show information about flap status, change ``open`` and ``close`` functions to ``openSlit`` and ``closeSlit`` and added ``openFlap`` and ``closeFlap``. Note that this does not drop backward capabilities. It only changes the key on the chimera script, not the drivers.

When showing information about flap status, capture ``NotImplementedError`` because a considerable number of domes don't have flaps.