### PR TITLE
Introduces the ``calibrationlamp`` instrument. 

### DIFF
--- a/src/chimera/core/chimera.sample.config
+++ b/src/chimera/core/chimera.sample.config
@@ -33,6 +33,10 @@ dome:
   mode: track
   telescope: /FakeTelescope/fake
 
+calibrationlamp:
+  name: fake
+  type: FakeCalibrationLamp
+
 controller:
   - type: Autofocus
     name: fake

--- a/src/chimera/core/systemconfig.py
+++ b/src/chimera/core/systemconfig.py
@@ -132,7 +132,8 @@ class SystemConfig (object):
                           "filterwheel", "filterwheels",
                           "dome", "domes",
                           "focuser", "focusers",
-                          "weatherstation", "weatherstations"]
+                          "weatherstation", "weatherstations",
+                          "calibrationlamp", "calibrationlamps"]
 
         self._instrumentsSections = self._specials + \
             ["instrument", "instruments"]

--- a/src/chimera/instruments/calibrationlamp.py
+++ b/src/chimera/instruments/calibrationlamp.py
@@ -1,0 +1,41 @@
+#! /usr/bin/env python
+# -*- coding: iso-8859-1 -*-
+
+# chimera - observatory automation system
+# Copyright (C) 2006-2007  P. Henrique Silva <henrique@astro.ufsc.br>
+# Copyright (C) 2006-2007  Antonio Kanaan <kanaan@astro.ufsc.br>
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+from chimera.core.chimeraobject import ChimeraObject
+from chimera.interfaces.calibrationlamp import CalibrationLampSwitch
+from chimera.core.lock import lock
+
+class CalibrationLampBase(ChimeraObject, CalibrationLampSwitch):
+
+    def __init__(self):
+        ChimeraObject.__init__(self)
+
+    @lock
+    def switchOn(self):
+        raise NotImplementedError()
+
+    @lock
+    def switchOff(self):
+        raise NotImplementedError()
+
+    def isSwitchedOn(self):
+        raise NotImplementedError()

--- a/src/chimera/instruments/dome.py
+++ b/src/chimera/instruments/dome.py
@@ -24,7 +24,7 @@ import Queue
 import threading
 
 from chimera.core.chimeraobject import ChimeraObject
-from chimera.interfaces.dome import Mode, DomeSlew, DomeSlit, DomeFlap, DomeLights, DomeSync
+from chimera.interfaces.dome import Mode, DomeSlew, DomeSlit, DomeFlap, DomeSync
 from chimera.core.lock import lock
 from chimera.core.exceptions import ObjectNotFoundException
 from chimera.core.exceptions import ChimeraException
@@ -34,7 +34,7 @@ from chimera.util.coord import Coord
 __all__ = ['DomeBase']
 
 
-class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeLights, DomeSync):
+class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeSync):
     def __init__(self):
         ChimeraObject.__init__(self)
 

--- a/src/chimera/instruments/fakecalibrationlamp.py
+++ b/src/chimera/instruments/fakecalibrationlamp.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python
+# -*- coding: iso-8859-1 -*-
+
+# chimera - observatory automation system
+# Copyright (C) 2006-2007  P. Henrique Silva <henrique@astro.ufsc.br>
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+from chimera.core.lock import lock
+
+from chimera.interfaces.calibrationlamp import CalibrationLampDimmer, IntensityOutOfRangeException
+from chimera.instruments.calibrationlamp import CalibrationLampBase
+
+import time
+import threading
+
+
+class FakeCalibrationLamp (CalibrationLampBase, CalibrationLampDimmer):
+
+    def __init__(self):
+        CalibrationLampBase.__init__(self)
+
+        self._isOn = False
+        self._intensity = 0.
+
+    @lock
+    def switchOn(self):
+        if not self.isSwitchedOn():
+            time.sleep(1.0)
+            self._isOn = True
+
+        return True
+
+    @lock
+    def switchOff(self):
+        if self.isSwitchedOn():
+            time.sleep(1.0)
+            self._isOn = False
+        return True
+
+    def isSwitchedOn(self):
+        return self._isOn
+
+    @lock
+    def setIntensity(self,intensity):
+        if 0. < intensity <= 100.:
+            self._intensity = intensity
+            return True
+        else:
+            raise IntensityOutOfRangeException('Intensity %.2f out of range. Must be between (0:100].')
+
+    @lock
+    def getIntensity(self):
+        return self._intensity

--- a/src/chimera/instruments/fakecalibrationlamp.py
+++ b/src/chimera/instruments/fakecalibrationlamp.py
@@ -35,6 +35,7 @@ class FakeCalibrationLamp (CalibrationLampBase, CalibrationLampDimmer):
 
         self._isOn = False
         self._intensity = 0.
+        self._irange = (0.,100.)
 
     @lock
     def switchOn(self):
@@ -56,12 +57,19 @@ class FakeCalibrationLamp (CalibrationLampBase, CalibrationLampDimmer):
 
     @lock
     def setIntensity(self,intensity):
-        if 0. < intensity <= 100.:
+        int_i, int_f = self.getRange()
+
+        if int_i < intensity <= int_f:
             self._intensity = intensity
             return True
         else:
-            raise IntensityOutOfRangeException('Intensity %.2f out of range. Must be between (0:100].')
+            raise IntensityOutOfRangeException('Intensity %.2f out of range. Must be between (%.2f:%.2f].'%(intensity,
+                                                                                                            int_i,
+                                                                                                            int_f))
 
     @lock
     def getIntensity(self):
         return self._intensity
+
+    def getRange(self):
+        return self._irange

--- a/src/chimera/interfaces/calibrationlamp.py
+++ b/src/chimera/interfaces/calibrationlamp.py
@@ -1,0 +1,100 @@
+#! /usr/bin/env python
+# -*- coding: iso-8859-1 -*-
+
+# chimera - observatory automation system
+# Copyright (C) 2006-2007  P. Henrique Silva <henrique@astro.ufsc.br>
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+from chimera.core.interface import Interface
+from chimera.core.exceptions import ChimeraException
+
+class IntensityOutOfRangeException(ChimeraException):
+    '''
+    Raise when the requested lamp intensity is out of range.
+    '''
+    pass
+
+class CalibrationLamp(Interface):
+    """
+    Interface to calibration lamps.
+    """
+
+    __config__ = {"device": "Unknown",
+
+                  "switch_timeout": None,  # Maximum number of seconds to wait for lamp to switch on
+
+                  "dome_az": None,  # Azimuth of the dome when taking a calibration image (flat field)
+
+                  "telescope_alt": None,  # Altitude of the telescope when taking a calibration image
+                  "telescope_az": None,   # Azimuth of the telescope when taking a calibration image
+
+
+
+                 }
+
+class CalibrationLampSwitch(CalibrationLamp):
+
+    def switchOn(self):
+        '''
+        Switch calibration lamp on.
+
+        @return: True if successful, False otherwise
+        @rtype: bool
+        '''
+        pass
+
+    def switchOff(self):
+        '''
+        Switch calibration lamp off.
+
+        @return: True if successful, False otherwise
+        @rtype: bool
+        '''
+        pass
+
+    def isSwitchedOn(self):
+        '''
+        Get current state of the calibration lamp.
+
+        @return: True if On, False otherwise
+        @rtype: bool
+        '''
+        pass
+
+class CalibrationLampDimmer(CalibrationLamp):
+
+    def setIntensity(self,intensity):
+        '''
+        Sets the intensity of the calibration lamp.
+
+        @param intensity: Desired intensity in percent (from 0. to 100.).
+        @type  intensity: float
+        '''
+        pass
+
+    def getIntensity(self):
+        '''
+        Return the current intensity level of the calibration lamp.
+
+        Note that a intensity of 0 does not mean that the lamp is switched off and a intensity >0 does not mean
+        that the lamp in switched on. This will be implementation dependent. The best way to check if a lamp is
+        on or off is with the "isSwitchedOn" function.
+
+        @return: Intensity in percentage, from 0. to 100.
+        @rtype: float
+        '''
+        pass

--- a/src/chimera/interfaces/calibrationlamp.py
+++ b/src/chimera/interfaces/calibrationlamp.py
@@ -81,7 +81,7 @@ class CalibrationLampDimmer(CalibrationLamp):
         '''
         Sets the intensity of the calibration lamp.
 
-        @param intensity: Desired intensity in percent (from 0. to 100.).
+        @param intensity: Desired intensity.
         @type  intensity: float
         '''
         pass
@@ -94,7 +94,15 @@ class CalibrationLampDimmer(CalibrationLamp):
         that the lamp in switched on. This will be implementation dependent. The best way to check if a lamp is
         on or off is with the "isSwitchedOn" function.
 
-        @return: Intensity in percentage, from 0. to 100.
+        @return: Current intensity
         @rtype: float
         '''
+        pass
+
+    def getRange(self):
+        """
+        Gets the dimmer total range
+        @rtype: tuple
+        @return: Start and end positions of the dimmer (start, end)
+        """
         pass

--- a/src/chimera/interfaces/dome.py
+++ b/src/chimera/interfaces/dome.py
@@ -220,33 +220,6 @@ class DomeFlap(Dome):
         @type  az: Coord
         """
 
-class DomeLights(Dome):
-    """"
-    Dome with lights
-    """
-
-    def lightsOn(self):
-        """
-        Ask the dome to turn on flat lights, if any.
-        @return: None
-        @rtype: None
-        """
-
-    def lightsOff(self):
-        """
-        Ask the dome to turn off flat lights, if any.
-        @return: None
-        @rtype: None
-        """
-
-    def isLightsOn(self):
-        """
-        Ask the dome if the flat lights are on, if any.
-        @return: None
-        @rtype: None
-        """
-
-
 class DomeSync(Dome):
     """
     Synchronism operations with a chosen telescope.

--- a/src/scripts/chimera-dome
+++ b/src/scripts/chimera-dome
@@ -48,21 +48,19 @@ class ChimeraDome (ChimeraCLI):
                                 help="Tell the dome to follow TELESCOPE when tracking"
                                 "(only utilized when using --track"))
 
-        self.addHelpGroup("CALIBRATIONLAMP", "CalibrationLamp")
+        self.addHelpGroup("LIGHT", "Dome lights control")
         self.addParameters(dict(name="calibrationlamp",
                                 default="/CalibrationLamp/0",
-                                helpGroup="CALIBRATIONLAMP",
+                                helpGroup="LIGHT",
                                 help="Calibration lamp to be used."))
 
         self.addParameters(dict(name="intensity",
                                 default=None,
                                 type=float,
-                                helpGroup="CALIBRATIONLAMP",
-                                help="Select calibration lamp intensity (from 0 to 100.)."))
+                                helpGroup="LIGHT",
+                                help="Select calibration lamp intensity."))
 
         self.addHelpGroup("COMMANDS", "Commands")
-
-        self.addHelpGroup("LIGHT", "Dome lights control")
 
     @action(help="Open dome slit", helpGroup="COMMANDS", actionGroup="SLIT")
     def openSlit(self, options):

--- a/src/scripts/chimera-dome
+++ b/src/scripts/chimera-dome
@@ -21,11 +21,12 @@
 
 
 from chimera.core.cli import ChimeraCLI, action
-from chimera.core.exceptions import ObjectNotFoundException
+from chimera.core.exceptions import printException, ObjectNotFoundException
 from chimera.util.coord import Coord
 from chimera.util.output import green, red
 
 from chimera.interfaces.dome import Mode
+from chimera.interfaces.calibrationlamp import IntensityOutOfRangeException
 
 import sys
 import copy
@@ -53,12 +54,6 @@ class ChimeraDome (ChimeraCLI):
                                 default="/CalibrationLamp/0",
                                 helpGroup="LIGHT",
                                 help="Calibration lamp to be used."))
-
-        self.addParameters(dict(name="intensity",
-                                default=None,
-                                type=float,
-                                helpGroup="LIGHT",
-                                help="Select calibration lamp intensity."))
 
         self.addHelpGroup("COMMANDS", "Commands")
 
@@ -114,9 +109,30 @@ class ChimeraDome (ChimeraCLI):
         except ObjectNotFoundException, e:
             self.exit('%s: Could not find requested calibration lamp.'% red('ERROR'))
 
-        if options.intensity is not None:
-            lamp.setIntensity(options.intensity)
         lamp.switchOn()
+        self.out(green("OK"))
+
+    @action(long="intensity",
+            type="float",
+            help="Set light intensity to specified value.",
+            helpGroup="LIGHT",
+            actionGroup="LIGHT")
+    def intensity(self, options):
+        self.out("Setting light intensity to %.2f ... "% options.intensity, end="")
+
+        lamp = None
+        try:
+            lamp = self.dome.getManager().getProxy(options.calibrationlamp)
+            lamp.setIntensity(options.intensity)
+        except ObjectNotFoundException, e:
+            self.exit('%s: Could not find requested calibration lamp.'% red('ERROR'))
+        except IntensityOutOfRangeException, e:
+            self.exit('%s: (%s)'% (red('ERROR'),
+                                    printException(e)))
+        except Exception,e:
+            self.exit('%s: (%s).'% (red('ERROR'),
+                                    printException(e)))
+
         self.out(green("OK"))
 
     @action(help="Track the telescope",

--- a/src/scripts/chimera-dome
+++ b/src/scripts/chimera-dome
@@ -112,8 +112,9 @@ class ChimeraDome (ChimeraCLI):
         lamp.switchOn()
         self.out(green("OK"))
 
-    @action(long="intensity",
+    @action(long="lights-intensity",
             type="float",
+            metavar="intensity",
             help="Set light intensity to specified value.",
             helpGroup="LIGHT",
             actionGroup="LIGHT")

--- a/src/scripts/chimera-dome
+++ b/src/scripts/chimera-dome
@@ -21,7 +21,9 @@
 
 
 from chimera.core.cli import ChimeraCLI, action
+from chimera.core.exceptions import ObjectNotFoundException
 from chimera.util.coord import Coord
+from chimera.util.output import green, red
 
 from chimera.interfaces.dome import Mode
 
@@ -45,6 +47,18 @@ class ChimeraDome (ChimeraCLI):
                                 helpGroup="TELESCOPE",
                                 help="Tell the dome to follow TELESCOPE when tracking"
                                 "(only utilized when using --track"))
+
+        self.addHelpGroup("CALIBRATIONLAMP", "CalibrationLamp")
+        self.addParameters(dict(name="calibrationlamp",
+                                default="/CalibrationLamp/0",
+                                helpGroup="CALIBRATIONLAMP",
+                                help="Calibration lamp to be used."))
+
+        self.addParameters(dict(name="intensity",
+                                default=None,
+                                type=float,
+                                helpGroup="CALIBRATIONLAMP",
+                                help="Select calibration lamp intensity (from 0 to 100.)."))
 
         self.addHelpGroup("COMMANDS", "Commands")
 
@@ -84,8 +98,12 @@ class ChimeraDome (ChimeraCLI):
             actionGroup="LIGHT")
     def lightsOff(self, options):
         self.out("Turning flat lights off ... ", end="")
-        self.dome.lightsOff()
-        self.out("OK")
+        try:
+            lamp = self.dome.getManager().getProxy(options.calibrationlamp)
+        except ObjectNotFoundException, e:
+            self.exit('%s: Could not find requested calibration lamp.'% red('ERROR'))
+        lamp.switchOff()
+        self.out(green("OK"))
 
     @action(long="lights-on",
             help="Turn flat light on",
@@ -93,8 +111,15 @@ class ChimeraDome (ChimeraCLI):
             actionGroup="LIGHT")
     def lightsOn(self, options):
         self.out("Turning flat lights on ... ", end="")
-        self.dome.lightsOn()
-        self.out("OK")
+        try:
+            lamp = self.dome.getManager().getProxy(options.calibrationlamp)
+        except ObjectNotFoundException, e:
+            self.exit('%s: Could not find requested calibration lamp.'% red('ERROR'))
+
+        if options.intensity is not None:
+            lamp.setIntensity(options.intensity)
+        lamp.switchOn()
+        self.out(green("OK"))
 
     @action(help="Track the telescope",
             helpGroup="COMMANDS",
@@ -142,6 +167,7 @@ class ChimeraDome (ChimeraCLI):
 
         self.out("Current dome azimuth: %s." % self.dome.getAz())
         self.out("Current dome mode: %s." % self.dome.getMode())
+
         if self.dome.getMode() == Mode.Track:
             self.out("Tracking: %s." % self.dome["telescope"])
 
@@ -150,6 +176,15 @@ class ChimeraDome (ChimeraCLI):
         else:
             self.out("Dome slit is closed.")
         self.out("=" * 40)
+
+        lampList = self.dome.getManager().getResourcesByClass("CalibrationLamp")
+
+        if len(lampList) > 0:
+            for lamp in lampList:
+                caliblamp = self.dome.getManager().getProxy(lamp)
+                onoff = green('ON') if caliblamp.isSwitchedOn() else red('OFF')
+                self.out('Lamp %s: %s'%(caliblamp.getLocation(),onoff) )
+            self.out("=" * 40)
 
     def __abort__(self):
         self.out("\naborting... ", endl="")


### PR DESCRIPTION
As suggested on issue #83. 

* Removed all references to ``domelights``.
* Added interface, base instrument and fake instrument.
* Modified chimera-dome script for the new usage. It is possible to work with more than one lamp easily. When info is issued it will show the status of each lamp (or nothing, if none is present).

To configure a single lamp:
```
  calibrationlamp:
    - name: fake
      type: FakeCalibrationLamp
      dome_az: 0
      telescope_alt: 90
      telescope_az: 45
```

On `chimera-dome --info`:

```
======================================== 
Dome: /FakeDome/fake (/dev/ttyS1). 
Current dome azimuth: 42.13. 
Current dome mode: None. 
Dome slit is closed. 
======================================== 
Lamp /FakeCalibrationLamp/fake: OFF 
======================================== 
```

Or a series of lamps:

```
  calibrationlamps:
    - name: fake1
      type: FakeCalibrationLamp
      dome_az: 0
      telescope_alt: 90
      telescope_az: 45

    - name: fake2
      type: FakeCalibrationLamp
      dome_az: 10
      telescope_alt: 90
      telescope_az: 55
```

On `chimera-dome --info`:

```
======================================== 
Dome: /FakeDome/fake (/dev/ttyS1). 
Current dome azimuth: 42.13. 
Current dome mode: None. 
Dome slit is closed. 
======================================== 
Lamp /FakeCalibrationLamp/fake1: OFF 
Lamp /FakeCalibrationLamp/fake2: OFF 
======================================== 
```
