### PR TITLE
Adds scheduler image output filename option. Fixes #104

### DIFF
--- a/src/chimera/controllers/scheduler/model.py
+++ b/src/chimera/controllers/scheduler/model.py
@@ -6,7 +6,6 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relation, backref
 
 engine = create_engine('sqlite:///%s' % DEFAULT_PROGRAM_DATABASE, echo=False)
-print '-- engine created with sqlite:///%s' % DEFAULT_PROGRAM_DATABASE
 metaData = MetaData()
 metaData.bind = engine
 
@@ -17,8 +16,7 @@ import datetime as dt
 
 class Targets(Base):
     __tablename__ = "targets"
-    print "model.py"
-    
+
     id     = Column(Integer, primary_key=True)
     name   = Column(String, default="Program") 
     type   = Column(String, default=None) 
@@ -40,8 +38,7 @@ class Targets(Base):
 
 class Program(Base):
     __tablename__ = "program"
-    print "model.py"
-    
+
     id     = Column(Integer, primary_key=True)
     tid    = Column(Integer, ForeignKey('targets.id'))
     name   = Column(String, ForeignKey("targets.name"))

--- a/src/scripts/chimera-sched
+++ b/src/scripts/chimera-sched
@@ -79,7 +79,7 @@ class ChimeraSched (ChimeraCLI):
                                 short="o",
                                 type="string",
                                 helpGroup="DB",
-                                help="Base filename including full path if needed.",
+                                help="Images base filename including full path if needed.",
                                 default="$NAME-$DATE-$TIME"))
 
 

--- a/src/scripts/chimera-sched
+++ b/src/scripts/chimera-sched
@@ -18,23 +18,22 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301, USA.
+import string
+import re
+import sys
+import os
+import shutil
+import time
 
 from chimera.core.cli import ChimeraCLI, action
 from chimera.core.constants import DEFAULT_PROGRAM_DATABASE
 from chimera.core.callback import callback
 from chimera.util.position import Position
 from chimera.util.output import blue, green, red
-
 from chimera.controllers.scheduler.status import SchedulerStatus
 from chimera.controllers.scheduler.states import State
 from chimera.controllers.scheduler.model import (Session, Program, Point,
-                                                 Expose, PointVerify, AutoFocus)
-
-import re
-import sys
-import os
-import shutil
-import time
+                                                 Expose)
 
 
 class ChimeraSched (ChimeraCLI):
@@ -75,7 +74,14 @@ class ChimeraSched (ChimeraCLI):
                                 helpGroup="DB",
                                 default="",
                                 help="Filename of the input database.",
-                                metavar="FILENAME"))
+                                metavar="FILENAME"),
+                           dict(name="output",
+                                short="o",
+                                type="string",
+                                helpGroup="DB",
+                                help="Base filename including full path if needed.",
+                                default="$NAME-$DATE-$TIME"))
+
 
     @action(long="new",
             help="Generate a new database from a text file (excluding all programs already in database)",
@@ -193,12 +199,9 @@ class ChimeraSched (ChimeraCLI):
                         imagetype, objname, str(position), filter, exptime, frames))
 
                     program.actions.append(Expose(shutter=shutter,
-                                                  filename="%s-$DATE-$TIME" % objname.replace(
-                                                      " ", ""),
-                                                  filter=filter,
-                                                  frames=frames,
-                                                  exptime=exptime,
-                                                  imageType=imagetype,
+                                                  filename=string.Template(options.output).safe_substitute(
+                                                      {'NAME': objname.replace(" ", "")}),
+                                                  filter=filter, frames=frames, exptime=exptime, imageType=imagetype,
                                                   objectName=objname))
                 self.out("")
                 programs.append(program)

--- a/src/scripts/chimera-sched
+++ b/src/scripts/chimera-sched
@@ -140,8 +140,7 @@ class ChimeraSched (ChimeraCLI):
             objname = None
 
             if params.get("coord", None):
-                position = Position.fromRaDec(
-                    params['ra'], params['dec'], params['epoch'])
+                position = Position.fromRaDec(params['ra'], params['dec'], params['epoch'])
 
             imagetype = params['imagetype'].upper()
             objname = params['objname'].replace("\"", "")
@@ -169,13 +168,9 @@ class ChimeraSched (ChimeraCLI):
 
                 if imagetype == "FLAT":
                     site = self._remoteManager.getProxy("/Site/0")
-                    flatPosition = Position.fromAltAz(
-                        site['flat_alt'], site['flat_az'])
+                    flatPosition = Position.fromAltAz(site['flat_alt'], site['flat_az'])
                     program.actions.append(Point(targetAltAz=flatPosition))
 
-                # if i == 0:
-                #    program.actions.append(AutoFocus(start=1500, end=3000, step=250, filter="R", exptime=10))
-                #    program.actions.append(PointVerify(here=True))
 
                 for exp in exps:
                     if exp.count(":") > 1:


### PR DESCRIPTION
This PR fixes #104 by adding a `-o` option to the `chimera-sched` script like the one on `chimera-cam`:

```
$ chimera-sched --help
...
    -o OUTPUT, --output=OUTPUT
                        Images base filename including full path if needed.
                        [default=$NAME-$DATE-$TIME]
...
``