### PR TITLE
Adds `features` method to check if an instrument or controller features an interface or not

### DIFF
--- a/src/chimera/core/chimeraobject.py
+++ b/src/chimera/core/chimeraobject.py
@@ -221,3 +221,12 @@ class ChimeraObject (RemoteObject, ILifeCycle):
 
     def getMetadata(self, request):
         return []
+
+    def features(self, interface):
+        """
+        Checks if self is an instance of a interface.
+        This is useful to check if some interface/capability is supported by an instrument
+        :param interface: One of from chimera interfaces
+        :return: True if is instance, False otherwise
+        """
+        return isinstance(self, interface)

--- a/src/chimera/core/tests/test_chimera_object.py
+++ b/src/chimera/core/tests/test_chimera_object.py
@@ -1,5 +1,4 @@
 
-
 from chimera.core.chimeraobject import ChimeraObject
 from chimera.core.methodwrapper import MethodWrapper
 from chimera.core.event         import event
@@ -186,7 +185,20 @@ class TestChimeraObject (object):
 
     def test_methods (self):
 
-        class Minimo (ChimeraObject):
+
+        class BaseClass(ChimeraObject):
+
+            __config__ = {"baseConfig": True}
+
+            @event
+            def baseEvent (self):
+                pass
+            def baseMethod (self):
+                pass
+            def _basePrivateMethod (self):
+                pass
+
+        class Minimo (BaseClass):
 
             CONST = 42
 
@@ -203,7 +215,7 @@ class TestChimeraObject (object):
             def doMethod (self):
                 return self.answer
 
-            #def doEvent (self):
+            # def doEvent (self):
             #    self.eventDone("Event works!")
 
             def doRaise (self):
@@ -239,3 +251,6 @@ class TestChimeraObject (object):
         # exceptions
         assert_raises(Exception, m.doRaise, ())
 
+        # features
+        assert m.features(BaseClass)  # Minimo is a BaseClass subclass
+        assert not m.features(basestring)  # But not a basestring subclass


### PR DESCRIPTION
As discussed on #124, I introduce a `features` method on `ChimeraObject` to check if the object is an instance of another object. That way, one can check if an instrument supports a part of the interface or not by doing, for example:

```python
from chimera.core.manager import Manager
from chimera.interfaces.dome import DomeFlap, DomeLights

m = Manager()

dome = m.getProxy('127.0.0.1:7666/Dome/0')
print 'Flap', dome.features(DomeFlap)
print 'Lights', dome.features(DomeLights)
```