### PR TITLE
Fix epoch on header

### DIFF
--- a/src/chimera/instruments/faketelescope.py
+++ b/src/chimera/instruments/faketelescope.py
@@ -47,6 +47,8 @@ class FakeTelescope (TelescopeBase):
 
         self._abort = threading.Event()
 
+        self._epoch = Epoch.J2000
+
         try:
             self._site = self.getManager().getProxy("/Site/0")
             self._gotSite = True
@@ -108,14 +110,6 @@ class FakeTelescope (TelescopeBase):
 
         self.slewBegin(position)
 
-        # Change position epoch to J2000.
-        # Most of the Telescopes must have this precession calculation, otherwise pointing to positions of epochs
-        # different of J2000 will point the telescope to a wrong position.
-        # This should be done after self.slewBegin()
-        if position.epoch != Epoch.J2000:
-            position = position.toEpoch(Epoch.J2000)
-
-
         ra_steps = position.ra - self.getRa()
         ra_steps = float(ra_steps / 10.0)
 
@@ -123,6 +117,7 @@ class FakeTelescope (TelescopeBase):
         dec_steps = float(dec_steps / 10.0)
 
         self._slewing = True
+        self._epoch = position.epoch
         self._abort.clear()
 
         status = TelescopeStatus.OK
@@ -272,7 +267,7 @@ class FakeTelescope (TelescopeBase):
 
     @lock
     def getPositionRaDec(self):
-        return Position.fromRaDec(self.getRa(), self.getDec())
+        return Position.fromRaDec(self.getRa(), self.getDec(), epoch=self._epoch)
 
     @lock
     def getPositionAltAz(self):

--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -160,9 +160,6 @@ class TelescopeBase(ChimeraObject,
     def getTargetAltAz(self):
         raise NotImplementedError()
 
-    def getSideOfPier(self):
-        raise NotImplementedError()
-
     @lock
     def syncObject(self, name):
         target = Simbad.lookup(name)

--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -230,7 +230,7 @@ class TelescopeBase(ChimeraObject,
                 # TODO: How to get ra,dec at start of exposure (not end)
                 ('RA', position.ra.toHMS().__str__(), 'Right ascension of the observed object'),
                 ('DEC', position.dec.toDMS().__str__(), 'Declination of the observed object'),
-                ("EQUINOX", position.epochString(), "coordinate epoch"),
+                ("EQUINOX", position.epochString()[1:], "coordinate epoch"),
                 ('ALT', self.getAlt().toDMS().__str__(),
                  'Altitude of the observed object'),
                 ('AZ', self.getAz().toDMS().__str__(),

--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -160,6 +160,9 @@ class TelescopeBase(ChimeraObject,
     def getTargetAltAz(self):
         raise NotImplementedError()
 
+    def getSideOfPier(self):
+        raise NotImplementedError()
+
     @lock
     def syncObject(self, name):
         target = Simbad.lookup(name)
@@ -217,6 +220,7 @@ class TelescopeBase(ChimeraObject,
         raise NotImplementedError()
 
     def getMetadata(self, request):
+        position = self.getPositionRaDec()
         return [('TELESCOP', self['model'], 'Telescope Model'),
                 ('OPTICS',   self['optics'], 'Telescope Optics Type'),
                 ('MOUNT', self['mount'], 'Telescope Mount Type'),
@@ -227,11 +231,9 @@ class TelescopeBase(ChimeraObject,
                  'Telescope focal reduction'),
                 # TODO: Convert coordinates to proper equinox
                 # TODO: How to get ra,dec at start of exposure (not end)
-                ('RA', self.getRa().toHMS().__str__(),
-                 'Right ascension of the observed object'),
-                ('DEC', self.getDec().toDMS().__str__(),
-                 'Declination of the observed object'),
-                ("EQUINOX", 2000.0, "coordinate epoch"),
+                ('RA', position.ra.toHMS().__str__(), 'Right ascension of the observed object'),
+                ('DEC', position.dec.toDMS().__str__(), 'Declination of the observed object'),
+                ("EQUINOX", position.epochString(), "coordinate epoch"),
                 ('ALT', self.getAlt().toDMS().__str__(),
                  'Altitude of the observed object'),
                 ('AZ', self.getAz().toDMS().__str__(),


### PR DESCRIPTION
The epoch on the image headers is set hardcoded to be 2000. Changed the `faketelescope` to be able to test different coordinates.