### PR TITLE
Weather station interface review

### DIFF
--- a/src/chimera/instruments/fakeweatherstation.py
+++ b/src/chimera/instruments/fakeweatherstation.py
@@ -174,6 +174,16 @@ class FakeWeatherStation(WeatherBase, WeatherTemperature, WeatherHumidity, Weath
         """
         return np.random.rand < 0.2
 
+    def sky_transparency(self, unit_out=units.pct):
+        """
+        Returns, in percent, the sky transparency
+        :param unit_out:
+        """
+        if unit_out not in self.__accepted_transparency_unit__:
+            raise OptionConversionException("Invalid transparency unit %s." % unit_out)
+
+        return WSValue(datetime.datetime.utcnow(), np.random.rand() * 100, unit_out)
+
 
 if __name__ == '__main__':
     fws = FakeWeatherStation()

--- a/src/chimera/instruments/weatherstation.py
+++ b/src/chimera/instruments/weatherstation.py
@@ -63,4 +63,9 @@ class WeatherBase(ChimeraObject, WeatherStation):
             rate = self.rain_rate()
             md += [('METRAIN', str(rate.value), ('[%s] Weather station rain rate' % rate.unit))]
 
+        # Sky Transparency
+        if self.features(WeatherTransparency):
+            transp = self.sky_transparency()
+            md += [('METSKTR', str(transp.value), ('[%s] Weather station Sky Transparency' % transp.unit))]
+
         return md

--- a/src/chimera/instruments/weatherstation.py
+++ b/src/chimera/instruments/weatherstation.py
@@ -17,13 +17,12 @@
 # 02110-1301, USA.
 
 from chimera.core.chimeraobject import ChimeraObject
-from chimera.interfaces.weatherstation import WeatherStation
-
+from chimera.interfaces.weatherstation import WeatherStation, WeatherTemperature, WeatherHumidity, WeatherWind, \
+    WeatherPressure, WeatherRain, WeatherTransparency
 import astropy.units as units
 
 
 class WeatherBase(ChimeraObject, WeatherStation):
-
     def __init__(self):
         ChimeraObject.__init__(self)
 
@@ -35,42 +34,33 @@ class WeatherBase(ChimeraObject, WeatherStation):
 
         return (value * unit_in).to(unit_out, equivalencies).value
 
-    def supports(self, feature=None):
-        if feature in self._supports:
-            return self._supports[feature]
-        else:
-            self.log.info("Invalid feature: %s" % str(feature))
-            return False
-
-    def humidity(self, unit_out=units.pct):
-        raise NotImplementedError()
-
-    def temperature(self, unit_out=units.Celsius):
-        raise NotImplementedError()
-
-    def wind_speed(self, unit_out=units.meter/units.second):
-        raise NotImplementedError()
-
-    def wind_direction(self, unit_out=units.degree):
-        raise NotImplementedError()
-
-    def dew_point(self, unit_out=units.Celsius):
-        raise NotImplementedError()
-
-    def pressure(self, unit_out=units.Pa):
-        raise NotImplementedError()
-
-    def rain(self, unit_out=units.imperial.inch/units.hour):
-        raise NotImplementedError()
-
     def getMetadata(self, request):
-        #TODO: Check if metadata parameter is implemented or not.
-        return [('METMODEL', str(self['model']), 'Weather station Model'),
-                ('METRH', str(self.humidity().value), ('[%s] Weather station relative humidity' % self.humidity().unit)),
-                ('METTEMP', str(self.temperature().value), ('[%s] Weather station temperature' % self.temperature().unit)),
-                ('METWINDS', str(self.wind_speed().value), ('[%s] Weather station wind speed' % self.wind_speed().unit)),
-                ('WINDDIR',  str(self.wind_direction().value), ('[%s] Weather station wind direction' % self.wind_direction().unit)),
-                ('METDEW',  str(self.dew_point().value), ('[%s] Weather station dew point' % self.dew_point().unit)),
-                ('METPRES', str(self.pressure().value), ('[%s] Weather station air pressure' % self.pressure().unit)),
-                ('METRAIN', str(self.rain().value), ('[%s] Weather station rain indicator' % self.rain().unit)),
-                ]
+        md = [('METMODEL', str(self['model']), 'Weather station Model')]
+
+        # Temperature
+        if self.features(WeatherTemperature):
+            temp, dew = self.temperature(), self.dew_point()
+            md += ([('METTEMP', str(temp.value), ('[%s] Weather station temperature' % temp.unit)),
+                    ('METDEW', str(dew.value), ('[%s] Weather station dew point' % dew.unit))])
+
+        # Humidity
+        if self.features(WeatherHumidity):
+            hum = self.humidity()
+            md += [('METRH', str(hum.value), ('[%s] Weather station relative humidity' % hum.unit))]
+        # Wind
+        if self.features(WeatherWind):
+            speed, direc = self.wind_speed(), self.wind_direction()
+            md += [('METWINDS', str(speed.value), ('[%s] Weather station wind speed' % speed.unit)),
+                   ('WINDDIR', str(direc.value), ('[%s] Weather station wind direction' % direc.unit))]
+
+        # Pressure
+        if self.features(WeatherPressure):
+            press = self.pressure()
+            md += [('METPRES', str(press.value), ('[%s] Weather station air pressure' % press.unit))]
+
+        # Rain
+        if self.features(WeatherRain):
+            rate = self.rain_rate()
+            md += [('METRAIN', str(rate.value), ('[%s] Weather station rain rate' % rate.unit))]
+
+        return md

--- a/src/chimera/interfaces/weatherstation.py
+++ b/src/chimera/interfaces/weatherstation.py
@@ -162,3 +162,18 @@ class WeatherRain(WeatherStation):
         Returns True if it is raining and False otherwise
         """
 
+
+class WeatherTransparency(WeatherStation):
+    """
+    Methods related to cloud and sky transparency
+    """
+
+    __accepted_transparency_unit__ = [units.pct]
+
+    def sky_transparency(self, unit_out=units.pct):
+        """
+        Returns sky transparency, or 100% - clouds coverage.
+
+        For a system with only two/three stages, the suggestion is to use:
+        0% for overcast, 50% to cloudy and 100% to clear
+        """

--- a/src/chimera/interfaces/weatherstation.py
+++ b/src/chimera/interfaces/weatherstation.py
@@ -28,71 +28,26 @@ from collections import namedtuple
 
 class WSValue(namedtuple('WSValue', 'time value unit')):
     """
-    Named tuple that represents a measure
+    Named tuple that represents a measurement
     """
-    pass
 
 
-class WeatherStation (Interface):
+class WeatherStation(Interface):
     """
     Instrument interface for weather stations
     """
 
-    __config__ = {"device": None,           # weather station device
-                  "model": "unknown",     # weather station model
+    __config__ = {"device": None,  # weather station device
+                  "model": "unknown",  # weather station model
                   }
 
 
-
+class WeatherHumidity(WeatherStation):
     """
     Humidity units accepted by the interface.
     """
     __accepted_humidity_units__ = [
         units.pct
-    ]
-
-    """
-    Temperature units accepted by the interface.
-    """
-    __accepted_temperature_units__ = [
-        units.Celsius,
-        units.Kelvin,
-        units.imperial.deg_F
-    ]
-
-    """
-    Speed units accepted by the interface.
-    """
-    __accepted_speed_units__ = [
-        units.meter / units.second,
-        units.kilometer / units.hour,
-        units.imperial.mile / units.hour,
-        units.imperial.foot / units.second,
-    ]
-
-    """
-    Direction units accepted by the interface.
-    """
-    __accepted_direction_unit__ = [
-        units.degree,
-        units.radian
-    ]
-
-    """
-    Pressure units accepted by the interface.
-    """
-    __accepted_pressures_unit__ = [
-        units.cds.mmHg,
-        units.bar,
-        units.cds.atm,
-        units.Pa]
-
-    """
-    Pressure units accepted by the interface.
-    """
-    __accepted_precipitation_unit__ = [
-        units.imperial.inch/units.hour,
-        units.millimeter/units.hour,
     ]
 
     def humidity(self, unit_out=units.pct):
@@ -101,7 +56,19 @@ class WeatherStation (Interface):
         :param unit: Unit in which the instrument should return the humidity.
         :return: the humidity.
         """
-        pass
+
+
+class WeatherTemperature(WeatherStation):
+    """
+    Methods related to temperature
+    """
+
+    # Temperature units accepted by the interface.
+    __accepted_temperature_units__ = [
+        units.Celsius,
+        units.Kelvin,
+        units.imperial.deg_F
+    ]
 
     def temperature(self, unit_out=units.Celsius):
         """
@@ -109,23 +76,6 @@ class WeatherStation (Interface):
         :param unit:  Unit in which the instrument should return the temperature.
         :return: the temperature.
         """
-        pass
-
-    def wind_speed(self, unit_out=units.meter/units.second):
-        """
-        Returns the wind speed in the chosen unit (Default: meters per second).
-        :param unit:  Unit in which the instrument should return the wind speed.
-        :return: the wind speed.
-        """
-        pass
-
-    def wind_direction(self, unit_out=units.degree):
-        """
-        Returns the wind direction in the chosen unit (Default: Degrees).
-        :param unit:  Unit in which the instrument should return the wind direction.
-        :return: the wind direction.
-        """
-        pass
 
     def dew_point(self, unit_out=units.Celsius):
         """
@@ -133,7 +83,53 @@ class WeatherStation (Interface):
         :param unit:  Unit in which the instrument should return the dew point.
         :return: the dew point temperature.
         """
-        pass
+
+
+class WeatherWind(WeatherStation):
+    """
+    Methods related to wind
+    """
+
+    # Wind Speed units accepted by the interface.
+    __accepted_speed_units__ = [
+        units.meter / units.second,
+        units.kilometer / units.hour,
+        units.imperial.mile / units.hour,
+        units.imperial.foot / units.second,
+    ]
+
+    # Wind Direction units accepted by the interface.
+    __accepted_direction_unit__ = [
+        units.degree,
+        units.radian
+    ]
+
+    def wind_speed(self, unit_out=units.meter / units.second):
+        """
+        Returns the wind speed in the chosen unit (Default: meters per second).
+        :param unit:  Unit in which the instrument should return the wind speed.
+        :return: the wind speed.
+        """
+
+    def wind_direction(self, unit_out=units.degree):
+        """
+        Returns the wind direction in the chosen unit (Default: Degrees).
+        :param unit:  Unit in which the instrument should return the wind direction.
+        :return: the wind direction.
+        """
+
+
+class WeatherPressure(WeatherStation):
+    """
+    Methods related to pressure
+    """
+
+    # Pressure units accepted by the interface.
+    __accepted_pressures_unit__ = [
+        units.cds.mmHg,
+        units.bar,
+        units.cds.atm,
+        units.Pa]
 
     def pressure(self, unit_out=units.Pa):
         """
@@ -141,12 +137,28 @@ class WeatherStation (Interface):
         :param unit:  Unit in which the instrument should return the pressure.
         :return: the pressure.
         """
-        pass
 
-    def rain(self, unit_out=units.imperial.inch/units.hour):
+
+class WeatherRain(WeatherStation):
+    """
+    Methods related to rain
+    """
+
+    # Precipitation units accepted by the interface.
+    __accepted_precipitation_unit__ = [
+        units.imperial.inch / units.hour,
+        units.millimeter / units.hour,
+    ]
+
+    def rain_rate(self, unit_out=units.imperial.inch / units.hour):
         """
         Returns the precipitation rate in the chosen unit (Default: inch/h).
         :param unit:  Unit in which the instrument should return the precipitation rate.
         :return: the precipitation rate.
         """
-        pass
+
+    def isRaining(self):
+        """
+        Returns True if it is raining and False otherwise
+        """
+

--- a/src/chimera/interfaces/weatherstation.py
+++ b/src/chimera/interfaces/weatherstation.py
@@ -177,3 +177,15 @@ class WeatherTransparency(WeatherStation):
         For a system with only two/three stages, the suggestion is to use:
         0% for overcast, 50% to cloudy and 100% to clear
         """
+
+class WeatherSafety(WeatherStation):
+    """
+    Methods related to weather enviroment safety.
+
+    Some weather stations can have some intelligency that returns to the OCS only if it is okay to open the dome or not.
+    """
+
+    def okToOpen(self):
+        """
+        Returns True if it is okay to open the dome and False otherwise.
+        """

--- a/src/scripts/chimera-seeing
+++ b/src/scripts/chimera-seeing
@@ -28,6 +28,7 @@ class ChimeraSeeing(ChimeraCLI):
         self.out("=" * 80)
         self.out("Seeing Monitor: %s %s (%s)" % (self.seeingmonitor.getLocation(), self.seeingmonitor["model"],
                                                  self.seeingmonitor["device"]))
+        self.out("=" * 80)
 
         for attr in ('seeing', 'seeing_at_zenith', 'airmass', 'flux'):
             try:

--- a/src/scripts/chimera-weather
+++ b/src/scripts/chimera-weather
@@ -4,6 +4,7 @@ import datetime
 import sys
 import exceptions
 from chimera.core.cli import ChimeraCLI, action
+from chimera.interfaces.weatherstation import WeatherSafety
 from chimera.util.output import red, green
 
 
@@ -26,6 +27,11 @@ class ChimeraWeather(ChimeraCLI):
         self.out("=" * 80)
         self.out("Weather Station: %s %s (%s)" % (self.weatherstation.getLocation(), self.weatherstation["model"],
                                                   self.weatherstation["device"]))
+
+        if self.weatherstation.features(WeatherSafety):
+            self.out('Dome is %s to open' % green("OK") if self.weatherstation.okToOpen() else red("NOT OK"))
+
+        self.out("=" * 80)
 
         for attr in ('temperature', 'dew_point', 'humidity', 'wind_speed', 'wind_direction', 'pressure', 'rain_rate',
                      'sky_transparency'):

--- a/src/scripts/chimera-weather
+++ b/src/scripts/chimera-weather
@@ -2,9 +2,7 @@
 
 import datetime
 import sys
-
 import exceptions
-
 from chimera.core.cli import ChimeraCLI, action
 from chimera.util.output import red, green
 
@@ -29,7 +27,8 @@ class ChimeraWeather(ChimeraCLI):
         self.out("Weather Station: %s %s (%s)" % (self.weatherstation.getLocation(), self.weatherstation["model"],
                                                   self.weatherstation["device"]))
 
-        for attr in ('temperature', 'dew_point', 'humidity', 'wind_speed', 'wind_direction', 'pressure', 'rain'):
+        for attr in ('temperature', 'dew_point', 'humidity', 'wind_speed', 'wind_direction', 'pressure', 'rain_rate',
+                     'sky_transparency'):
             try:
                 v = self.weatherstation.__getattr__(attr)()
                 if isinstance(v, exceptions.NotImplementedError) or not v:

--- a/src/scripts/chimera-weather
+++ b/src/scripts/chimera-weather
@@ -38,6 +38,8 @@ class ChimeraWeather(ChimeraCLI):
                 self.out(t + "  " + attr.replace('_', ' ') + ": {0.value:.2f} {0.unit:s} ".format(v))
             except NotImplementedError:
                 pass
+            except AttributeError:
+                pass
 
         self.out("=" * 80)
 


### PR DESCRIPTION
This PR changes the interface of the Weather Station to:
* Divide the Weather station features in WeatherTemperature, WeatherHumidity, WeatherRain, and so on... This is useful to use the `features` method added on #134.
* Add new types of weather information: `Sky Transparency` to be used with instruments such as RASICAM and AAG Cloud Watcher and `WeatherSafety` which is mean to be used with some instruments that are able only tell that is okay to observe or not.