### PR TITLE
Add rice compression

### DIFF
--- a/src/chimera/util/image.py
+++ b/src/chimera/util/image.py
@@ -1,41 +1,33 @@
 import urllib2
-
+from astropy.io.fits import Header
 from chimera.core.remoteobject import RemoteObject
 from chimera.core.exceptions import ChimeraException
 from chimera.core.version import _chimera_name_, _chimera_long_description_
-
 from chimera.util.coord import Coord
 from chimera.util.position import Position
 from chimera.util.sextractor import SExtractor
-
 from astropy.io import fits
 from astropy import wcs
-
 import numpy as N
-
 import os
 import string
 import datetime as dt
-
 import bz2
 import gzip
 import zipfile
-
 import sys
 import shutil
-
 from UserDict import DictMixin
-
 import logging
+
 log = logging.getLogger(__name__)
 
 
-class WCSNotFoundException (ChimeraException):
+class WCSNotFoundException(ChimeraException):
     pass
 
 
-class ImageUtil (object):
-
+class ImageUtil(object):
     @staticmethod
     def formatDate(datetime):
         if type(datetime) == float:
@@ -161,10 +153,7 @@ class ImageUtil (object):
         return False
 
 
-
-
-class Image (DictMixin, RemoteObject):
-
+class Image(DictMixin, RemoteObject):
     """
     Class to manipulate FITS images with a Pythonic taste.
 
@@ -181,8 +170,8 @@ class Image (DictMixin, RemoteObject):
     """
 
     @staticmethod
-    def fromFile(filename, fix = False, mode = "update"):
-        fd = fits.open(filename, mode = mode)
+    def fromFile(filename, fix=False, mode="update"):
+        fd = fits.open(filename, mode=mode)
         img = Image(filename, fd)
 
         if fix:
@@ -203,30 +192,37 @@ class Image (DictMixin, RemoteObject):
 
         filename = ImageUtil.makeFilename(filename)
 
-        hdu = fits.PrimaryHDU(data)
-
         headers = [("DATE", ImageUtil.formatDate(dt.datetime.utcnow()), "date of file creation"),
                    ("AUTHOR", _chimera_name_, 'author of the data'),
                    ("FILENAME", os.path.basename(filename), "name of the file")]
 
+        hdu = fits.PrimaryHDU()
         # TODO: Implement BITPIX support
         hdu.scale('int16', '', bzero=32768, bscale=1)
 
         if imageRequest:
             headers += imageRequest.headers
 
-        for header in headers:
+        for h in headers:
             try:
-                hdu.header.set(*header)
+                hdu.header.set(*h)
             except Exception, e:
-                log.warning("Couldn't add %s: %s" % (str(header), str(e)))
+                log.warning("Couldn't add %s: %s" % (str(h), str(e)))
 
-        hduList = fits.HDUList([hdu])
-        hduList.writeto(filename)
-        hduList.close()
+        if imageRequest['compress_format'] == 'fits_rice':
+            filename = os.path.splitext(filename)[0] + ".fz"
+            img = fits.CompImageHDU(data=data, header=hdu.header, compression_type='RICE_1')
+            img.writeto(filename, checksum=True)
 
-        del hduList
-        del hdu
+        else:
+            hdu.data = data
+
+            hduList = fits.HDUList([hdu])
+            hduList.writeto(filename)
+            hduList.close()
+
+            del hduList
+            del hdu
 
         return Image.fromFile(filename)
 
@@ -245,7 +241,6 @@ class Image (DictMixin, RemoteObject):
 
     def close(self):
         self._fd.close()
-
 
     def http(self, http=None):
         if http:
@@ -416,6 +411,9 @@ class Image (DictMixin, RemoteObject):
             gzfp.close()
             rawfp.close()
             os.unlink(filename)
+        elif format.lower().startswith('fits_'):
+            # compression methods inherent to fits standard, are done when saving image.
+            return
         else:  # zip
             zipfilename = filename + '.zip'
             zipfp = zipfile.ZipFile(zipfilename, 'w', zipfile.ZIP_DEFLATED)

--- a/src/chimera/util/image.py
+++ b/src/chimera/util/image.py
@@ -1,24 +1,25 @@
+import bz2
+import datetime as dt
+import gzip
+import logging
+import os
+import shutil
+import string
+import sys
 import urllib2
-from astropy.io.fits import Header
-from chimera.core.remoteobject import RemoteObject
+import zipfile
+from UserDict import DictMixin
+
+import numpy as N
+from astropy import wcs
+from astropy.io import fits
+
 from chimera.core.exceptions import ChimeraException
-from chimera.core.version import _chimera_name_, _chimera_long_description_
+from chimera.core.remoteobject import RemoteObject
+from chimera.core.version import _chimera_name_
 from chimera.util.coord import Coord
 from chimera.util.position import Position
 from chimera.util.sextractor import SExtractor
-from astropy.io import fits
-from astropy import wcs
-import numpy as N
-import os
-import string
-import datetime as dt
-import bz2
-import gzip
-import zipfile
-import sys
-import shutil
-from UserDict import DictMixin
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/src/chimera/util/image.py
+++ b/src/chimera/util/image.py
@@ -200,8 +200,6 @@ class Image(DictMixin, RemoteObject):
         # TODO: Implement BITPIX support
         hdu.scale('int16', '', bzero=32768, bscale=1)
 
-        if imageRequest:
-            headers += imageRequest.headers
 
         for h in headers:
             try:
@@ -209,12 +207,14 @@ class Image(DictMixin, RemoteObject):
             except Exception, e:
                 log.warning("Couldn't add %s: %s" % (str(h), str(e)))
 
-        if imageRequest['compress_format'] == 'fits_rice':
-            filename = os.path.splitext(filename)[0] + ".fz"
-            img = fits.CompImageHDU(data=data, header=hdu.header, compression_type='RICE_1')
-            img.writeto(filename, checksum=True)
+        if imageRequest:
+            headers += imageRequest.headers
+            if imageRequest['compress_format'] == 'fits_rice':
+                filename = os.path.splitext(filename)[0] + ".fz"
+                img = fits.CompImageHDU(data=data, header=hdu.header, compression_type='RICE_1')
+                img.writeto(filename, checksum=True)
 
-        else:
+        if not imageRequest or imageRequest['compress_format'] != 'compress_rice':
             hdu.data = data
 
             hduList = fits.HDUList([hdu])

--- a/src/scripts/chimera-cam
+++ b/src/scripts/chimera-cam
@@ -18,7 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301, USA.
-
+import os
 
 from chimera.core.cli import ChimeraCLI, action, ParameterType
 from chimera.core.callback import callback
@@ -43,12 +43,14 @@ currentFrameReadoutStart = 0
 def get_compressed_name(filename, compression):
     if compression.lower() == 'no':
         return filename
-    if compression.lower() == 'bz2':
+    elif compression.lower() == 'bz2':
         return filename+'.bz2'
-    if compression.lower() == 'gzip':
+    elif compression.lower() == 'gzip':
         return filename+'.gz'
-    if compression.lower() == 'zip':
+    elif compression.lower() == 'zip':
         return filename+'.zip'
+    elif compression.lower() == 'fits_rice':
+        return os.path.splitext(filename)[0] + '.fz'
 
 class ChimeraCam (ChimeraCLI):
 
@@ -119,7 +121,7 @@ class ChimeraCam (ChimeraCLI):
                                 help="Compress the output file using FORMAT. Use --compress=no to disable it.",
                                 helpGroup="EXPOSE",
                                 type=ParameterType.CHOICE,
-                                choices=["BZ2", "ZIP", "GZIP", "NO", "bz2", "zip", "gzip", "no"],
+                                choices=["FITS_RICE", "BZ2", "ZIP", "GZIP", "NO", "fits_rice", "bz2", "zip", "gzip", "no"],
                                 default="no"),
                            dict(name="ignore_dome",
                                 long="ignore-dome",


### PR DESCRIPTION
Adds RICE_ONE FITS standard compression option for chimera. To use it:

``chimera-cam -t NNN --compress fits_rice``

For more info on compressed fits files:
http://docs.astropy.org/en/stable/io/fits/usage/unfamiliar.html
https://heasarc.gsfc.nasa.gov/fitsio/fpack/