### PR TITLE
Fix issues #164, #160 and #37.

### DIFF
--- a/src/chimera/controllers/imageserver/imageserver.py
+++ b/src/chimera/controllers/imageserver/imageserver.py
@@ -75,7 +75,7 @@ class ImageServer(ChimeraObject):
     def register(self, image):
         try:
             if len(self.imagesByID) > self['max_images']:
-                remove_items = self.imagesByID.keys()[:len(self.imagesByID)-self['max_images']]
+                remove_items = self.imagesByID.keys()[:-self['max_images']]
 
                 for item in remove_items:
                     self.log.debug('Unregistering image %s' % item)

--- a/src/scripts/chimera-cam
+++ b/src/scripts/chimera-cam
@@ -484,8 +484,6 @@ class ChimeraCam (ChimeraCLI):
                     ds9.set("scale mode 99.5")
                     ds9.displayImage(image)
 
-                image.close()
-
         camera.exposeBegin += exposeBegin
         camera.exposeComplete += exposeComplete
         camera.readoutBegin += readoutBegin


### PR DESCRIPTION
Fixes a memory leak on chimera that allows imageserver to open an unrestricted number of fits files (#164). The user can control the number of images added to the queue (default=10) in the configuration file. Control is done when registering images. This also fixes the “Too many open files” issue, #160 and #37, without the need to track all calls to camera.expose().