### PR TITLE
astropy for py2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     scripts=chimera_scripts,
 
     # installation happens in the specified order
-    install_requires=[  "astropy",
+    install_requires=[  "astropy<3",
                          "numpy>=1.8.0",
                          "pyephem",
                          "Pyro>=3.16",


### PR DESCRIPTION
The newer versions ``astropy`` only support Python 3. 
I inserted a restriction on ``setup.py`` to use the Python 2 compatible versions.

In Portuguese:
>  astropy agora (a partir da versão 3) só é compatível com python 3. 
Como estou aprendendo a usar o github, fiz uma atualização no ``setup.py``por aqui.