### PR TITLE
Cli

### DIFF
--- a/src/chimera/core/cli.py
+++ b/src/chimera/core/cli.py
@@ -569,17 +569,18 @@ class ChimeraCLI(object):
 
             inst_proxy = None
 
-            try:
-                inst_proxy = Proxy(inst.location)
-            except ObjectNotFoundException:
-                if inst.required:
-                    self.exit(
-                        f"Couldn't find {inst.name.capitalize()}. (see --help for more information)"
-                    )
+            if inst.location:
+                try:
+                    inst_proxy = Proxy(inst.location)
+                except ObjectNotFoundException:
+                    if inst.required:
+                        self.exit(
+                            f"Couldn't find {inst.name.capitalize()}. (see --help for more information)"
+                        )
 
-            # save values in CLI object (which users are supposed to inherits
-            # from).
-            setattr(self, inst.name, inst_proxy)
+                # save values in CLI object (which users are supposed to inherits
+                # from).
+                setattr(self, inst.name, inst_proxy)
 
     def __start__(self, options, args):
         pass

--- a/src/scripts/chimera-focus
+++ b/src/scripts/chimera-focus
@@ -88,7 +88,7 @@ class ChimeraFocus (ChimeraCLI):
                "Use start-end, as in 1000-6000 to run from 1000 to 6000.",
                metavar="START-END")
     def autofocus_range(self, value):
-        r = re.compile("(?P<start>\d+)-(?P<end>\d+)")
+        r = re.compile(r"(?P<start>\d+)-(?P<end>\d+)")
         m = r.match(value)
         if not m:
             raise ValueError("Invalid start-end range")

--- a/src/scripts/chimera-focus
+++ b/src/scripts/chimera-focus
@@ -186,7 +186,11 @@ class ChimeraFocus (ChimeraCLI):
                  " This option is exclusive, you cannot move manually at the same time.")
     def auto(self, options):
 
-        if not self.autofocus:
+        try:
+            if not self.autofocus:
+                self.exit(
+                    "No Autofocus controller available. Try --autofocus=..., or --help.")
+        except AttributeError:
             self.exit(
                 "No Autofocus controller available. Try --autofocus=..., or --help.")
 


### PR DESCRIPTION
Fixes chimera-focus:

- Fixes autofocus regular expression
- Fixes crash when no autofocus is configured and gracefully exit with `No Autofocus controller available. Try --autofocus=..., or --help.` message

Original crash message:
```console
% chimera-focus --info
/Users/william/workspace/chimera/.venv/bin/chimera-focus:91: SyntaxWarning: invalid escape sequence '\d'
  r = re.compile("(?P<start>\d+)-(?P<end>\d+)")
Exception in thread Thread-1 (_run):
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/william/workspace/chimera/chimera/src/chimera/core/cli.py", line 481, in _run
    self._setupObjects(self.options)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/Users/william/workspace/chimera/chimera/src/chimera/core/cli.py", line 573, in _setupObjects
    inst_proxy = Proxy(inst.location)
  File "/Users/william/workspace/chimera/chimera/src/chimera/core/proxy.py", line 16, in __init__
    self.location: Location = Location(location)
                              ~~~~~~~~^^^^^^^^^^
  File "/Users/william/workspace/chimera/chimera/src/chimera/core/location.py", line 65, in __init__
    _, __, self._class, self._name, ___ = self.parse(loc)
                                          ~~~~~~~~~~^^^^^
  File "/Users/william/workspace/chimera/chimera/src/chimera/core/location.py", line 122, in parse
    raise InvalidLocationException("Invalid location name (must be non-blank).")
chimera.core.exceptions.InvalidLocationException: Invalid location name (must be non-blank).
^C%                                                  
```