### PR TITLE
Update .git-blame-ignore-revs with new hashes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,3 +8,6 @@ b6bd5651f0a9bd68b64a068829f38539b59ff0b5
 
 # move from black to ruff format
 50c7affca0d0788551392e96d4333dc4c181b7e0
+
+# black formatting
+f54a1bdfed16d96e38f7e29c2f419be2aace700d


### PR DESCRIPTION
Added commit hashes for formatting changes to ignore.