### PR TITLE
fix(fakefocuser): return primitive types to keep metadata bus-serializable

### DIFF
--- a/src/chimera/instruments/fakefocuser.py
+++ b/src/chimera/instruments/fakefocuser.py
@@ -71,18 +71,18 @@ class FakeFocuser(FocuserBase):
     @lock
     def get_position(self, axis=FocuserAxis.Z):
         self._check_axis(axis)
-        return self._position
+        return int(self._position)
 
     def get_range(self, axis=FocuserAxis.Z):
         self._check_axis(axis)
         return (0, 7000)
 
     def get_temperature(self):
-        return random.randrange(10, 30)
+        return float(random.randrange(10, 30))
 
     def _set_position(self, n):
         self.log.info(f"Changing focuser to {n}")
-        self._position = n
+        self._position = int(n)
 
     def _in_range(self, n):
         min_pos, max_pos = self.get_range()


### PR DESCRIPTION
## Summary
- `FakeFocuser.get_position` and `get_temperature` could leak `numpy` scalar types (e.g. `np.int64`) into the FITS metadata returned by `FocuserBase.get_metadata`, which the bus encoder cannot serialize.
- Coerce `_position` to `int` on assignment and cast `get_position`/`get_temperature` return values to native Python `int`/`float`.

## Context
Observed in the wild as:
```
TypeError: Encoding objects of type numpy.int64 is unsupported
```
…raised from `chimera/core/bus.py` when a remote bus tried to serialize a `Response` containing `('FOCUS', np.int64(2500), ...)`. The numpy value originates from autofocus routines that call `move_to(position)` with a numpy scalar; `_set_position` previously stored it as-is.

The fix is at the source (the focuser itself) rather than papering over it in `get_metadata`, so all consumers of `get_position` / `get_temperature` see a primitive.

## Test plan
- [x] Run a fake focuser with the metadata pipeline and confirm no `numpy.int64` serialization error
- [x] Verify `move_to` still works when called with numpy scalars
