### PR TITLE
docs: replace anaconda/pip install with uv workflow

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -4,105 +4,112 @@ Getting Started
 Prerequisites
 -------------
 
-Your platform of choice will need to have the following software installed:
+Your platform of choice will need the following software installed:
 
-* Python 2.7; **Chimera** has not been ported to Python3 yet.
-* Git;
+* `uv`_ — Python package and project manager. uv will provision the right Python interpreter for you, so a system Python is not required.
+* Git.
+
+.. _uv: https://docs.astral.sh/uv/
+
+Installing uv
+-------------
+
+On macOS and Linux::
+
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+
+On Windows (PowerShell)::
+
+   powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+Other installation methods (Homebrew, pipx, standalone binaries) are described in the `uv installation guide`_.
+
+.. _uv installation guide: https://docs.astral.sh/uv/getting-started/installation/
 
 Installation
 ------------
 
-Current build status: |build_status|
-
-.. |build_status| image:: https://travis-ci.org/astroufsc/chimera.svg?branch=master
-    :target: https://travis-ci.org/astroufsc/chimera
-
-.. _above:
-
-**Chimera** currently lives in Github_. To install it, go to your install directory, and run:
+**Chimera** currently lives on Github_. Clone the repository and let uv handle the environment and dependencies for you:
 
 .. _Github: https://github.com/astroufsc/chimera
 
 ::
 
-   pip install git+https://github.com/astroufsc/chimera.git
+   git clone https://github.com/astroufsc/chimera.git
+   cd chimera
+   uv sync
 
-This will clone the official repository and install into your system. Make sure that you have the right permissions to
-do this.
+``uv sync`` creates a project-local virtual environment in ``.venv/``, installs Chimera in editable mode, and installs every dependency pinned in ``uv.lock``. The required Python interpreter (3.13 or newer) is downloaded automatically if it is not already available.
 
-Distutils will install automatically the following Python dependencies:
+Running Chimera
+---------------
+
+Once installed, use ``uv run`` to launch the CLI entry points without having to activate the virtual environment::
+
+   uv run chimera -vv
+
+The other entry points work the same way::
+
+   uv run chimera-cam
+   uv run chimera-tel
+   uv run chimera-dome
+   uv run chimera-focus
+   uv run chimera-filter
+   uv run chimera-rotator
+   uv run chimera-sched
+   uv run chimera-weather
+
+On the first run, Chimera creates a sample configuration file with fake instruments under ``$HOME/.chimera/chimera.config`` (``%HOMEPATH%\.chimera\chimera.config`` on Windows).
+
+If you prefer the traditional workflow, activate the environment once and then call the scripts directly:
+
+On macOS and Linux::
+
+   source .venv/bin/activate
+   chimera -vv
+
+On Windows (PowerShell)::
+
+   .venv\Scripts\Activate.ps1
+   chimera -vv
+
+Installing without a clone
+--------------------------
+
+To install Chimera into an existing uv-managed project without cloning the repository::
+
+   uv add git+https://github.com/astroufsc/chimera.git
+
+Or, to install it as a standalone tool that exposes the ``chimera`` commands globally::
+
+   uv tool install git+https://github.com/astroufsc/chimera.git
+
+Dependencies
+------------
+
+uv resolves and installs the dependencies declared in ``pyproject.toml`` (pinned in ``uv.lock``), including:
 
 * astropy
-* PyYAML: 3.10
-* RO: 3.3.0
-* SQLAlchemy: 0.9.1
-* numpy: 1.8.0
-* pyephem: 3.7.5.2
-* python-dateutil: 2.2
-* suds: 0.4
+* msgspec
+* numpy
+* pyephem
+* pynng
+* python-dateutil
+* PyYAML
+* rich
+* SQLAlchemy
 
+Development setup
+-----------------
 
-Alternative Methods
--------------------
+To work on Chimera itself, install the ``dev`` and ``docs`` dependency groups as well::
 
-Alternatively, you can follow the how-tos below to install it on a virtual enviroment and on Windows.
+   uv sync --all-groups
 
-Windows using `Anaconda`_ Python distribution
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Run the test suite with::
 
-These steps were tested with `Anaconda`_ version 2.3.0.
+   uv run pytest
 
-* Download and install the latest `Anaconda`_ version for Windows.
+Build the documentation with::
 
-* Download and install git for windows at https://msysgit.github.io/
-
-* Install Visual C++ 9.0 for Python 2.7 (for pyephem package): https://www.microsoft.com/en-us/download/details.aspx?id=44266
-
-* Open the Anaconda Command Prompt and install chimera using pip:
-
-::
-
-   pip install git+https://github.com/astroufsc/chimera.git
-
-* After install, you can run chimera and its scripts by executing
-
-::
-
-   python C:\Anaconda\Scripts\chimera -vv
-
-On the first run, chimera creates a sample configuration file with fake instruments on ``%HOMEPATH%\chimera\chimera.config``
-
-* **Optional:** For a convenient access create a VBS script named ``chimera.vbs`` on Desktop containing:
-
-::
-
-    CreateObject("Wscript.Shell").Run("C:\Anaconda\python.exe C:\Anaconda\Scripts\chimera -vvvvv")
-
-.. _Anaconda: http://continuum.io
-
-Python virtual environment
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-For those constrained by limited access to their platform, restrictions to the system
-provided python or any other reason, the python tool virtualenv_ provides an
-isolated environment in which to install **Chimera**.
-
-* Install virtualenv_;
-* Go to your install dir, and run:
-
-  ::
-
-    virtualenv v_name
-
-* This will generate a directory named *v_name*; go in and type
-
-  ::
-
-    source bin/activate
-
-  (See the documentation for details).
-
-* From tyhe same directory, you can now proceed to install as described above.
-
-.. _virtualenv: https://virtualenv.pypa.io/en/latest/
-
+   uv run --group docs sphinx-build -b html docs docs/_build/html


### PR DESCRIPTION
## Summary

The Getting Started guide in `docs/gettingstarted.rst` still described a Python 2.7 / Anaconda / virtualenv installation, even though the project now requires Python 3.13+ and uses `uv` (`uv_build`) per `pyproject.toml`. This PR rewrites the page so the documented workflow matches the actual build system.

Changes:

- Install `uv` on macOS, Linux, and Windows.
- Clone the repo and run `uv sync` — auto-provisions Python 3.13 and installs from `uv.lock`.
- Run every CLI entry point declared in `pyproject.toml` (`chimera`, `chimera-cam`, `chimera-filter`, `chimera-tel`, `chimera-dome`, `chimera-rotator`, `chimera-focus`, `chimera-sched`, `chimera-weather`) via `uv run`, plus a traditional `source .venv/bin/activate` alternative.
- Document clone-less installs via `uv add git+...` and `uv tool install git+...`.
- Refresh the dependency list to match the current `pyproject.toml` (astropy, msgspec, numpy, pyephem, pynng, python-dateutil, PyYAML, rich, SQLAlchemy).
- Add a development section: `uv sync --all-groups`, `uv run pytest`, and the Sphinx build command for the `docs` group.

Only `docs/gettingstarted.rst` is touched — no code or other docs changed.

## Test plan

- [ ] `uv run --group docs sphinx-build -b html docs docs/_build/html` builds without warnings.
- [ ] Render the page on Read the Docs (or locally) and confirm formatting looks right.
- [ ] Follow the documented steps on a clean machine and verify `uv sync` + `uv run chimera -vv` works end-to-end.