### PR TITLE
Honor control() return value and size the manager pool explicitly

### DIFF
--- a/src/chimera/cli/chimera.py
+++ b/src/chimera/cli/chimera.py
@@ -3,9 +3,11 @@
 # SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
 
 import argparse
+import faulthandler
 import logging
 import os.path
 import platform
+import signal
 import sys
 from typing import Any
 
@@ -160,6 +162,11 @@ class ChimeraCLI:
 
 
 def main():
+    # kill -USR1 <pid> dumps every thread's stack to stderr: the only way
+    # to diagnose a stuck server in place (ptrace/py-spy are typically
+    # unavailable inside containers)
+    if hasattr(signal, "SIGUSR1"):
+        faulthandler.register(signal.SIGUSR1, all_threads=True)
     cli = ChimeraCLI()
     cli.run()
 

--- a/src/chimera/core/bus.py
+++ b/src/chimera/core/bus.py
@@ -3,6 +3,7 @@ import logging
 import queue
 import selectors
 import threading
+import time
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
@@ -10,6 +11,7 @@ from typing import Any, NamedTuple
 
 import msgspec
 
+from chimera.core.exceptions import RequestTimeoutException
 from chimera.core.protocol import (
     Event,
     Messages,
@@ -306,16 +308,26 @@ class Bus:
 
         self._push(ping)
 
-        try:
-            response = self._pop(ping.src, timeout=timeout)
-        except queue.Empty:
-            return ping.pong(ok=False)
-        if response is None or not isinstance(response, Pong):
-            return None
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                response = self._pop(
+                    ping.src, timeout=max(0.001, deadline - time.monotonic())
+                )
+            except queue.Empty:
+                return ping.pong(ok=False)
+            if response is None:
+                # shutdown flushed the queues: the bus is really dead
+                return None
+            if not isinstance(response, Pong):
+                # stale leftover of an earlier timed-out exchange on this
+                # src queue; drop it and keep waiting for our pong
+                log.debug(
+                    f"bus: discarding stale message while waiting for pong: {response}"
+                )
+                continue
+            return response
 
-        return response
-
-    # TODO: add timeout?
     def request(
         self,
         *,
@@ -324,7 +336,18 @@ class Bus:
         method: str,
         args: list[Any] | None = None,
         kwargs: dict[str, Any] | None = None,
+        timeout: float | None = None,
     ) -> None | Response:
+        """Send a request and wait for its response.
+
+        With ``timeout`` (seconds) a lost response raises
+        :class:`~chimera.core.exceptions.RequestTimeoutException` instead of
+        blocking forever; without it the call blocks until the response
+        arrives or the bus shuts down.  Stale messages left on the queue by
+        earlier timed-out exchanges (a late pong, a response to a request
+        that already timed out) are discarded instead of being mistaken for
+        a dead bus.
+        """
         request = Protocol.request(
             src=parse_url(src).url,
             dst=parse_url(dst).url,
@@ -335,11 +358,26 @@ class Bus:
 
         self._push(request)
 
-        response = self._pop(request.src)
-        if response is None or not isinstance(response, Response):
-            raise RuntimeError("bus is dead")
-
-        return response
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while True:
+            remaining = (
+                None if deadline is None else max(0.001, deadline - time.monotonic())
+            )
+            try:
+                response = self._pop(request.src, timeout=remaining)
+            except queue.Empty:
+                raise RequestTimeoutException(
+                    f"no response for {request.dst}.{method}() after {timeout}s"
+                ) from None
+            if response is None:
+                # shutdown flushed the queues: the bus is really dead
+                raise RuntimeError("bus is dead")
+            if not isinstance(response, Response) or response.id != request.id:
+                log.debug(
+                    f"bus: discarding stale message while waiting for response: {response}"
+                )
+                continue
+            return response
 
     def subscribe(
         self,

--- a/src/chimera/core/bus.py
+++ b/src/chimera/core/bus.py
@@ -61,10 +61,18 @@ class Bus:
     def __init__(self, url: str):
         self.url = create_url(url, cls="Bus")
 
-        # request handlers and event callbacks run on this pool and may issue
-        # nested requests that block until another worker serves them: the
-        # default size (cpu count + 4) deadlocks under load on small machines
+        # request handlers run on this pool and may issue nested requests
+        # that block until another worker serves them: the default size
+        # (cpu count + 4) deadlocks under load on small machines
         self._pool = ThreadPoolExecutor(max_workers=64)
+
+        # event callbacks get their OWN pool: they make nested requests and
+        # can be slow (uploads, dome syncs), and sharing the request pool
+        # let a burst of events starve the workers their own nested
+        # requests needed - deadlocking the bus (2026-07-20)
+        self._event_pool = ThreadPoolExecutor(
+            max_workers=64, thread_name_prefix="bus-event"
+        )
 
         self._running = threading.Event()
         self._bus_started = threading.Event()
@@ -117,6 +125,9 @@ class Bus:
 
             self._process_queue_future.result()
             self._pool.shutdown()
+            # don't wait for in-flight callbacks: one blocked on a request
+            # that will never be answered would hang the shutdown forever
+            self._event_pool.shutdown(wait=False, cancel_futures=True)
 
             self._inbound.close()
             self._internal.close()
@@ -579,10 +590,20 @@ class Bus:
 
             for callback in self._callbacks[event_id].values():
                 method = callback.callable
-                # NOTE: we cannot see exception happening inside the event handlers,
-                #       so we schedule a check on the future result in a separate task.
-                event_future = self._pool.submit(method, *event.args, **event.kwargs)
-                self._pool.submit(self._check_event_result, event, event_future)
+                # callbacks run on their own pool: they routinely make
+                # nested requests (and can be slow, e.g. uploads), and on
+                # the request pool each in-flight event held a worker while
+                # waiting for another worker to serve its nested request -
+                # enough events deadlocked the whole bus (seen 2026-07-20:
+                # 41 workers parked in nested request(), server dead)
+                event_future = self._event_pool.submit(
+                    method, *event.args, **event.kwargs
+                )
+                # done-callback instead of a blocked checker thread (the
+                # old pattern burned a SECOND worker per event just to log)
+                event_future.add_done_callback(
+                    lambda future, event=event: self._check_event_result(event, future)
+                )
         except Exception:
             log.exception("error handling event")
 

--- a/src/chimera/core/bus.py
+++ b/src/chimera/core/bus.py
@@ -59,7 +59,10 @@ class Bus:
     def __init__(self, url: str):
         self.url = create_url(url, cls="Bus")
 
-        self._pool = ThreadPoolExecutor()
+        # request handlers and event callbacks run on this pool and may issue
+        # nested requests that block until another worker serves them: the
+        # default size (cpu count + 4) deadlocks under load on small machines
+        self._pool = ThreadPoolExecutor(max_workers=64)
 
         self._running = threading.Event()
         self._bus_started = threading.Event()

--- a/src/chimera/core/chimeraobject.py
+++ b/src/chimera/core/chimeraobject.py
@@ -146,9 +146,14 @@ class ChimeraObject(ILifeCycle, metaclass=MetaObject):
                 run_condition = self.control()
             loop_time = time.monotonic() - t0
 
+            if not run_condition:
+                # control() asked to stop: exit and release the pool worker
+                break
+
             time_to_wake_up = (1.0 / self.get_hz()) - loop_time
             if time_to_wake_up > 0:
-                run_condition = not self._loop_abort.wait(time_to_wake_up)
+                if self._loop_abort.wait(time_to_wake_up):
+                    run_condition = False
             else:
                 self.log.warning(
                     f"{self.get_location()}: control loop took more than {1.0 / self.get_hz()} seconds to run: {loop_time:.3f} s"

--- a/src/chimera/core/exceptions.py
+++ b/src/chimera/core/exceptions.py
@@ -64,6 +64,10 @@ class ObjectNotFoundException(ChimeraException):
     pass
 
 
+class RequestTimeoutException(ChimeraException):
+    """A bus request got no response within the caller-supplied timeout."""
+
+
 class NotValidChimeraObjectException(ChimeraException):
     pass
 

--- a/src/chimera/core/manager.py
+++ b/src/chimera/core/manager.py
@@ -66,8 +66,12 @@ class Manager:
 
         self.resources = ResourcesManager()
         self.class_loader = ClassLoader()
+        # one worker per object __main__ loop: the default pool size
+        # (cpu count + 4) starves objects on small machines once several
+        # control loops run forever
         self._pool = concurrent.futures.ThreadPoolExecutor(
-            thread_name_prefix=f"{self._bus.url.bus}/Manager-"
+            max_workers=64,
+            thread_name_prefix=f"{self._bus.url.bus}/Manager-",
         )
 
         # shutdown event

--- a/src/chimera/core/proxy.py
+++ b/src/chimera/core/proxy.py
@@ -9,11 +9,16 @@ __all__ = ["Proxy", "ProxyMethod"]
 
 
 class Proxy:
-    def __init__(self, url: str | URL, bus: Bus):
+    def __init__(self, url: str | URL, bus: Bus, timeout: float | None = None):
+        """``timeout`` (seconds) bounds every method call made through this
+        proxy: a lost response raises RequestTimeoutException instead of
+        blocking forever.  Leave it None for objects with legitimately
+        long-running methods (exposures, slews)."""
         self.__url__ = parse_url(url)
         self.__resolved_url__: URL | None = None
         self.__proxy_url__ = create_url(bus=bus.url.bus, cls="Proxy")
         self.__bus__ = bus
+        self.__timeout__ = timeout
 
     def resolve(self) -> None:
         if self.__resolved_url__ is not None:
@@ -36,7 +41,7 @@ class Proxy:
     def get_proxy(self, url: str) -> "Proxy":
         """Returns a Proxy for a resource relative to this Proxy's URL."""
         resolved_url = resolve_url(url, bus=self.__url__.bus)
-        proxy = Proxy(resolved_url, self.__bus__)
+        proxy = Proxy(resolved_url, self.__bus__, timeout=self.__timeout__)
         proxy.resolve()
         return proxy
 
@@ -86,6 +91,7 @@ class ProxyMethod:
             # FIXME: requests should use tuple
             args=list(args),
             kwargs=kwargs,
+            timeout=self.proxy.__timeout__,
         )
 
         # FIXME: bus should not return None, either good or error

--- a/src/chimera/instruments/fakeweatherstation.py
+++ b/src/chimera/instruments/fakeweatherstation.py
@@ -34,10 +34,17 @@ class FakeWeatherStation(
         WeatherStationBase.__init__(self)
         self["model"] = "FakeWeatherStation v1.0"
 
-    def _hour_in_radians(self, hour=datetime.datetime.now(datetime.UTC).hour):
+    def _hour_in_radians(self, hour=None):
         """
         For testing purposes, the function converts a given hour in radians.
+
+        The default must be computed per call: a `datetime.now()` default
+        argument is evaluated once at import time, freezing the simulated
+        weather for the whole life of the process.
         """
+        if hour is None:
+            now = datetime.datetime.now(datetime.UTC)
+            hour = now.hour + now.minute / 60.0
         return (math.pi / 12.0) * hour
 
     def get_last_measurement_time(self):


### PR DESCRIPTION
## Bug

`ChimeraObject.__main__` overwrites the result of `control()` with the result of the idle wait:

```python
run_condition = self.control()
...
run_condition = not self._loop_abort.wait(time_to_wake_up)
```

so returning `False` from `control()` — the documented way to stop the loop — never stops anything. Every object's `__main__` runs forever, and each one permanently occupies a worker of `Manager._pool`, which is a default `ThreadPoolExecutor` (`max_workers = cpu_count + 4`).

On small machines this starves later-registered objects **silently**: on a 4-core server (8 workers) running a sample-config observatory (11 objects), the last objects registered never got a pool worker, so their `control()` never ran at all. Proxy requests kept working (they are served by the bus pool), so the system looked healthy while e.g. the Scheduler's control loop never ticked.

Found while soak-testing a fake-hardware observatory on a 4-core VPS: a `faulthandler` stack dump showed every pool worker parked in the idle `__main__` wait — including for objects whose `control()` had returned `False`/`None`.

## Fix

- `__main__` exits when `control()` returns falsy, releasing the worker. Objects that want a periodic loop keep returning `True` — unchanged behavior.
- Give the pool an explicit `max_workers=64` so there is one worker per long-lived control loop regardless of host CPU count.

## Testing

- `uv run pytest`: **70 passed / 5 failed** with this change vs **68 / 7** on current master (two stale tests start passing; the remaining failures/errors predate this PR — old `Manager()` signatures).
- Verified on the 4-core deployment: after the fix all controllers tick at their configured `freq`.


## Follow-up commits (from continued soak testing)

- **Size the bus pool explicitly to survive nested requests** — same failure family, worse variant: `Bus._pool` is also a default-sized executor, and request handlers / event callbacks issue nested synchronous requests (`Bus.request()` has no timeout — the existing TODO). On the 4-core test server, an error-path event callback plus an in-flight exposure exhausted all 8 workers and deadlocked the entire bus (no requests, events or pings) for two days; confirmed with a `faulthandler` all-threads dump. A proper `request()` timeout is the deeper fix but needs discussion, since legitimate calls (e.g. exposures) block for minutes.
- **Compute FakeWeatherStation simulated time per call** — `hour=datetime.now().hour` as a default argument is evaluated once at import, freezing the simulated weather for the process lifetime; long-running fake observatories never saw the daily humidity/temperature cycle.
- **Discard stale messages and add optional request timeout** — resolves the `request()` timeout TODO flagged above, plus a spurious-error fix in the same code path:
  - `Bus.request()` and `Bus.ping()` share a per-source response queue. A ping that timed out (5 s) left its late `Pong` on the queue; the next `request()` popped it, failed the `isinstance` check and raised `RuntimeError("bus is dead")` on a perfectly healthy bus. Both now discard messages that are not the awaited reply (wrong type or mismatched request id) and keep waiting — only a real shutdown reports a dead bus.
  - `Bus.request()` gains an optional `timeout` (seconds) raising a typed `RequestTimeoutException`, and `Proxy` a matching per-proxy timeout (`Proxy(url, bus, timeout=60)`) forwarded to every method call and inherited by `get_proxy()`. The default stays `None`, so long-running calls (exposures, slews) are unaffected — this is opt-in for callers that know their requests are short. Motivation: responses can be silently dropped when a remote send fails (`_push` is deliberately non-blocking), which left a CLI blocked forever on its first request — observed freezing a scripted supervisor pipeline for six hours until killed by hand.
- **Run event callbacks on a dedicated pool** — the root cause behind the deadlocks described above, finally caught red-handed with a `faulthandler` all-threads dump (41/64 workers parked in nested `request()` calls, most of the rest in the event result-checker). Event callbacks shared `Bus._pool` with request handlers while routinely making nested synchronous requests, so each in-flight event held a worker *while waiting for another worker*; every event also burned a second worker parked on `future.result()` just to log handler exceptions. Callbacks now run on their own executor and exception logging uses `Future.add_done_callback` (zero extra workers). After this change a production-like soak with heavy event traffic (per-frame upload callbacks) ran a full night without a single stall — the same workload previously deadlocked the bus within hours, twice.
- **Dump all thread stacks on SIGUSR1** — registers `faulthandler` in the `chimera` entry point so `kill -USR1 <pid>` prints every thread's stack. This is what made the diagnosis above possible: py-spy/gdb need `SYS_PTRACE`, which containers typically don't have.
