### PR TITLE
Autoguider: interface reconciled against TheSkyX and PHD2, chimera-guide CLI, and a scheduler autoguide action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ chimera-tel = "chimera.cli.tel:main"
 chimera-dome = "chimera.cli.dome:main"
 chimera-rotator = "chimera.cli.rotator:main"
 chimera-focus = "chimera.cli.focus:main"
-chimera-guide = "chimera.cli.guide:main"
+chimera-guider = "chimera.cli.guider:main"
 chimera-sched = "chimera.cli.sched:main"
 chimera-weather = "chimera.cli.weather:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ chimera-tel = "chimera.cli.tel:main"
 chimera-dome = "chimera.cli.dome:main"
 chimera-rotator = "chimera.cli.rotator:main"
 chimera-focus = "chimera.cli.focus:main"
+chimera-guide = "chimera.cli.guide:main"
 chimera-sched = "chimera.cli.sched:main"
 chimera-weather = "chimera.cli.weather:main"
 

--- a/src/chimera/cli/guide.py
+++ b/src/chimera/cli/guide.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
+
+
+import sys
+import threading
+
+from chimera.core.version import chimera_version
+from chimera.interfaces.autoguider import GuiderStatus
+
+from .cli import ChimeraCLI, ParameterType, action
+
+
+class ChimeraGuide(ChimeraCLI):
+    def __init__(self):
+        ChimeraCLI.__init__(
+            self, "chimera-guide", "Autoguider controller", chimera_version
+        )
+
+        self.add_help_group("GUIDER", "Autoguider")
+        self.add_instrument(
+            name="guider",
+            cls="Autoguider",
+            required=True,
+            help_group="GUIDER",
+            help="Autoguider instrument to be used",
+        )
+
+        self.add_parameters(
+            dict(
+                name="recalibrate",
+                long="recalibrate",
+                type=ParameterType.BOOLEAN,
+                help_group="GUIDER",
+                help="Discard the current calibration and recalibrate before guiding.",
+                default=False,
+            ),
+            dict(
+                name="nowait",
+                long="nowait",
+                type=ParameterType.BOOLEAN,
+                help_group="GUIDER",
+                help="Don't wait for the guider to settle, return immediately.",
+                default=False,
+            ),
+            dict(
+                name="ra_only",
+                long="ra-only",
+                type=ParameterType.BOOLEAN,
+                help_group="GUIDER",
+                help="Dither only in right ascension.",
+                default=False,
+            ),
+        )
+
+        self.add_help_group("COMMANDS", "Commands")
+
+    @action(help="Start guiding", help_group="COMMANDS")
+    def start(self, options):
+        settled = threading.Event()
+
+        def star_acquired(position):
+            self.out(f"Guide star acquired at {position}.")
+
+        def guide_start(position):
+            self.out(f"Guiding started at {position}, waiting to settle ...")
+            settled.set()
+
+        self.guider.star_acquired += star_acquired
+        self.guider.guide_start += guide_start
+
+        self.out("Starting autoguider ... ", end="")
+        try:
+            self.guider.start_guiding(options.recalibrate, not options.nowait)
+            self.out("OK")
+        except Exception as e:
+            self.exit(f"ERROR ({e})")
+
+        if not options.nowait and not settled.is_set():
+            # settled before the event subscription was in place
+            self.out("Guiding started and settled.")
+
+    @action(help="Stop guiding", help_group="COMMANDS")
+    def stop(self, options):
+        self.out("Stopping autoguider ... ", end="")
+        self.guider.stop_guiding()
+        self.out("OK")
+
+    @action(help="Abort guiding as soon as possible", help_group="COMMANDS")
+    def abort(self, options):
+        self.out("Aborting autoguider ... ", end="")
+        self.guider.abort()
+        self.out("OK")
+
+    @action(
+        long="dither",
+        type="float",
+        help="Dither the guide star position by up to AMOUNT pixels",
+        metavar="AMOUNT",
+        help_group="COMMANDS",
+    )
+    def dither(self, options):
+        self.out(f"Dithering by up to {options.dither} pixels ... ", end="")
+        try:
+            self.guider.dither(options.dither, options.ra_only, not options.nowait)
+            self.out("OK")
+        except Exception as e:
+            self.exit(f"ERROR ({e})")
+
+    @action(
+        long="find-star",
+        help="Find a guide star in the current field of view",
+        help_group="COMMANDS",
+    )
+    def find_star(self, options):
+        self.out("Looking for a guide star ... ", end="")
+        try:
+            position = self.guider.find_star()
+            self.out(f"OK (found at {position})")
+        except Exception as e:
+            self.exit(f"ERROR ({e})")
+
+    @action(
+        long="monitor",
+        help="Print guider offsets until interrupted (Ctrl-C)",
+        help_group="COMMANDS",
+    )
+    def monitor(self, options):
+        stopped = threading.Event()
+
+        def offset_complete(offset):
+            self.out(
+                "#%05d dx: %8.3f dy: %8.3f ra: %8.3f dec: %8.3f snr: %6.2f"
+                % (
+                    offset.get("frame") or 0,
+                    offset.get("dx") or 0.0,
+                    offset.get("dy") or 0.0,
+                    offset.get("ra_distance") or 0.0,
+                    offset.get("dec_distance") or 0.0,
+                    offset.get("snr") or 0.0,
+                )
+            )
+
+        def star_lost():
+            self.out("Guide star lost!")
+
+        def guide_stop(state, msg=None):
+            self.out(f"Guiding stopped ({state}).")
+            stopped.set()
+
+        self.guider.offset_complete += offset_complete
+        self.guider.star_lost += star_lost
+        self.guider.guide_stop += guide_stop
+
+        self.out("Monitoring guider (Ctrl-C to quit) ...")
+        try:
+            stopped.wait()
+        except KeyboardInterrupt:
+            pass
+
+    @action(short="i", help="Print guider current information", help_group="COMMANDS")
+    def info(self, options):
+        self.out("=" * 40)
+        self.out(f"Autoguider: {self.guider.get_location()}")
+        status = self.guider.get_status()
+        self.out(f"Status: {status}")
+        self.out(f"Guiding: {self.guider.is_guiding()}")
+        if status == GuiderStatus.ERROR:
+            self.out("(guider in error state or not connected)")
+        self.out("=" * 40)
+
+
+def main():
+    cli = ChimeraGuide()
+    cli.run(sys.argv)
+    cli.wait()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/chimera/cli/guider.py
+++ b/src/chimera/cli/guider.py
@@ -15,7 +15,7 @@ from .cli import ChimeraCLI, ParameterType, action
 class ChimeraGuide(ChimeraCLI):
     def __init__(self):
         ChimeraCLI.__init__(
-            self, "chimera-guide", "Autoguider controller", chimera_version
+            self, "chimera-guider", "Autoguider controller", chimera_version
         )
 
         self.add_help_group("GUIDER", "Autoguider")

--- a/src/chimera/cli/sched.py
+++ b/src/chimera/cli/sched.py
@@ -17,6 +17,7 @@ from astropy.time import Time
 from chimera.controllers.scheduler.model import (
     AutoFlat,
     AutoFocus,
+    Autoguide,
     Expose,
     Point,
     PointVerify,
@@ -36,6 +37,7 @@ from .cli import ChimeraCLI, action
 action_dict = {
     "autofocus": AutoFocus,
     "autoflat": AutoFlat,
+    "autoguide": Autoguide,
     "pointverify": PointVerify,
     "point": Point,
     "expose": Expose,

--- a/src/chimera/controllers/scheduler/controller.py
+++ b/src/chimera/controllers/scheduler/controller.py
@@ -30,6 +30,7 @@ class Scheduler(ChimeraObject):
         "dome": "/Dome/0",
         "autofocus": "/Autofocus/0",
         "autoflat": "/Autoflat/0",
+        "autoguider": "/Autoguider/0",
         "point_verify": "/PointVerify/0",
         "operator": "/Operator/0",
         "site": "/Site/0",

--- a/src/chimera/controllers/scheduler/executor.py
+++ b/src/chimera/controllers/scheduler/executor.py
@@ -6,6 +6,7 @@ from chimera.controllers.scheduler.handlers import (
     ActionHandler,
     AutoFlatHandler,
     AutoFocusHandler,
+    AutoguideHandler,
     ExposeHandler,
     PointHandler,
     PointVerifyHandler,
@@ -13,6 +14,7 @@ from chimera.controllers.scheduler.handlers import (
 from chimera.controllers.scheduler.model import (
     AutoFlat,
     AutoFocus,
+    Autoguide,
     Expose,
     Point,
     PointVerify,
@@ -40,6 +42,7 @@ class ProgramExecutor:
             Point: PointHandler,
             AutoFocus: AutoFocusHandler,
             AutoFlat: AutoFlatHandler,
+            Autoguide: AutoguideHandler,
             PointVerify: PointVerifyHandler,
         }
 

--- a/src/chimera/controllers/scheduler/handlers.py
+++ b/src/chimera/controllers/scheduler/handlers.py
@@ -240,6 +240,29 @@ class AutoFlatHandler(ActionHandler):
         skyflat.abort()
 
 
+class AutoguideHandler(ActionHandler):
+    @staticmethod
+    @requires("autoguider")
+    def process(action):
+        autoguider = AutoguideHandler.autoguider
+
+        try:
+            if action.enable:
+                autoguider.start_guiding(
+                    recalibrate=action.recalibrate, wait=action.wait
+                )
+            else:
+                autoguider.stop_guiding()
+        except Exception as e:
+            print_exception(e)
+            raise ProgramExecutionException("Error while autoguiding")
+
+    @staticmethod
+    def abort(action):
+        autoguider = copy.copy(AutoguideHandler.autoguider)
+        autoguider.abort()
+
+
 class PointVerifyHandler(ActionHandler):
     @staticmethod
     @requires("point_verify")

--- a/src/chimera/controllers/scheduler/model.py
+++ b/src/chimera/controllers/scheduler/model.py
@@ -113,6 +113,21 @@ class AutoFlat(Action):
         return f"Flat fields: filter={self.filter} frames={self.frames}"
 
 
+class Autoguide(Action):
+    __tablename__ = "action_autoguide"
+    __mapper_args__ = {"polymorphic_identity": "Autoguide"}
+
+    id = Column(Integer, ForeignKey("action.id"), primary_key=True)
+    enable = Column(Boolean, default=True)  # True: start guiding, False: stop guiding
+    recalibrate = Column(Boolean, default=False)  # recalibrate before guiding
+    wait = Column(Boolean, default=True)  # block until guiding settled/started
+
+    def __str__(self):
+        if self.enable:
+            return f"autoguide: start (recalibrate={self.recalibrate})"
+        return "autoguide: stop"
+
+
 class PointVerify(Action):
     __tablename__ = "action_pv"
     __mapper_args__ = {"polymorphic_identity": "PointVerify"}

--- a/src/chimera/controllers/scheduler/sample-sched.yaml
+++ b/src/chimera/controllers/scheduler/sample-sched.yaml
@@ -28,6 +28,11 @@ programs:
             -   action: pointverify
                 here: True
 
+            -   action: autoguide       # Enable autoguiding before the science exposures
+                enable: True
+                recalibrate: False
+                wait: True              # Block until guiding has settled
+
             -   action: expose
                 filter: V
                 frames: 1
@@ -49,6 +54,9 @@ programs:
                 exptime: 5
                 image_type: OBJECT
                 object_name: obj1 acq
+
+            -   action: autoguide       # Stop autoguiding after the science exposures
+                enable: False
 
     # new target with no autofocus or pointverify
     -   program:

--- a/src/chimera/instruments/fakeautoguider.py
+++ b/src/chimera/instruments/fakeautoguider.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
+"""Fake autoguider that pretends to guide, for testing and simulations.
+
+It keeps no hardware connection: star acquisition always succeeds at a
+fixed position and guiding/dithering settle instantly. While guiding it
+publishes offset_complete telemetry so consumers of that event, such as
+chimera-guide --monitor, can be exercised without hardware.
+"""
+
+import random
+
+from chimera.core.chimeraobject import ChimeraObject
+from chimera.core.lock import lock
+from chimera.interfaces.autoguider import (
+    Autoguider,
+    GuiderException,
+    GuiderStatus,
+)
+
+
+class FakeAutoguider(ChimeraObject, Autoguider):
+    __config__ = {
+        "freq": 1.0,  # simulated correction rate (Hz)
+        "scatter": 0.4,  # rms of the simulated guide error (pixels)
+        "pixel_scale": 0.5,  # arcsec/pixel, for the ra/dec distance fields
+    }
+
+    def __init__(self):
+        ChimeraObject.__init__(self)
+        self._status = GuiderStatus.OFF
+        self._lock_position = [512.0, 512.0]  # fake guide star position (pixels)
+        self._frame = 0
+
+    # Autoguider interface
+
+    @lock
+    def start_guiding(self, recalibrate=False, wait=False):
+        position = self.find_star()
+        self._status = GuiderStatus.GUIDING
+        self.guide_start(position)
+        return position
+
+    def stop_guiding(self):
+        self._stop(GuiderStatus.OFF)
+
+    def abort(self):
+        self._stop(GuiderStatus.ABORTED)
+
+    def is_guiding(self):
+        return self._status == GuiderStatus.GUIDING
+
+    def get_status(self):
+        return self._status
+
+    @lock
+    def dither(self, amount=None, ra_only=None, wait=False):
+        if not self.is_guiding():
+            raise GuiderException("Cannot dither: not guiding.")
+
+        amount = float(self["dither_amount"] if amount is None else amount)
+        ra_only = bool(self["dither_ra_only"] if ra_only is None else ra_only)
+
+        dx = amount
+        dy = 0.0 if ra_only else amount
+        self._lock_position = [self._lock_position[0] + dx, self._lock_position[1] + dy]
+        self.dither_complete([dx, dy], GuiderStatus.OK)
+
+    @lock
+    def find_star(self):
+        self.star_acquired(self._lock_position)
+        return self._lock_position
+
+    # simulated telemetry
+
+    def control(self):
+        if self.is_guiding():
+            self._frame += 1
+            scatter = float(self["scatter"])
+            dx = random.gauss(0.0, scatter)
+            dy = random.gauss(0.0, scatter)
+            scale = float(self["pixel_scale"])
+            self.offset_complete(
+                {
+                    "frame": self._frame,
+                    "dx": dx,
+                    "dy": dy,
+                    "ra_distance": dx * scale,
+                    "dec_distance": dy * scale,
+                    "snr": random.uniform(20.0, 60.0),
+                }
+            )
+        return True
+
+    # internals
+
+    def _stop(self, status):
+        was_guiding = self.is_guiding()
+        self._status = status
+        if was_guiding:
+            self.guide_stop(status)

--- a/src/chimera/instruments/fakeautoguider.py
+++ b/src/chimera/instruments/fakeautoguider.py
@@ -5,7 +5,7 @@
 It keeps no hardware connection: star acquisition always succeeds at a
 fixed position and guiding/dithering settle instantly. While guiding it
 publishes offset_complete telemetry so consumers of that event, such as
-chimera-guide --monitor, can be exercised without hardware.
+chimera-guider --monitor, can be exercised without hardware.
 """
 
 import random
@@ -35,26 +35,33 @@ class FakeAutoguider(ChimeraObject, Autoguider):
     # Autoguider interface
 
     @lock
-    def start_guiding(self, recalibrate=False, wait=False):
+    def start_guiding(
+        self, recalibrate: bool = False, wait: bool = False
+    ) -> list[float] | None:
         position = self.find_star()
         self._status = GuiderStatus.GUIDING
         self.guide_start(position)
         return position
 
-    def stop_guiding(self):
+    def stop_guiding(self) -> None:
         self._stop(GuiderStatus.OFF)
 
-    def abort(self):
+    def abort(self) -> None:
         self._stop(GuiderStatus.ABORTED)
 
-    def is_guiding(self):
+    def is_guiding(self) -> bool:
         return self._status == GuiderStatus.GUIDING
 
-    def get_status(self):
+    def get_status(self) -> GuiderStatus:
         return self._status
 
     @lock
-    def dither(self, amount=None, ra_only=None, wait=False):
+    def dither(
+        self,
+        amount: float | None = None,
+        ra_only: bool | None = None,
+        wait: bool = False,
+    ) -> None:
         if not self.is_guiding():
             raise GuiderException("Cannot dither: not guiding.")
 
@@ -67,7 +74,7 @@ class FakeAutoguider(ChimeraObject, Autoguider):
         self.dither_complete([dx, dy], GuiderStatus.OK)
 
     @lock
-    def find_star(self):
+    def find_star(self) -> list[float]:
         self.star_acquired(self._lock_position)
         return self._lock_position
 

--- a/src/chimera/interfaces/autoguider.py
+++ b/src/chimera/interfaces/autoguider.py
@@ -9,6 +9,14 @@ from chimera.util.enum import Enum
 
 
 class GuiderStatus(Enum):
+    """Guider states.
+
+    Every implementation must be able to report OFF, GUIDING and ERROR.
+    The rest are optional: a backend that has no separate calibration step
+    never reports CALIBRATING, and one with no settling notion never
+    reports SETTLING. Clients must not treat their absence as an error.
+    """
+
     OK = "OK"
     GUIDING = "GUIDING"
     CALIBRATING = "CALIBRATING"
@@ -28,12 +36,21 @@ class GuiderException(ChimeraException):
 
 
 class Autoguider(Interface):
+    """A closed-loop guider driving corrections into the mount.
+
+    Guiding is normally performed by an external package (TheSkyX, PHD2),
+    which owns the guide camera and the mount connection itself. This
+    interface therefore does not name chimera instruments: an
+    implementation talks to its backend and reports what it is doing.
+
+    Positions and dither amounts are in GUIDER DETECTOR PIXELS, not sky
+    units, since that is the only frame every backend agrees on.
+    """
+
     __config__ = {
-        "site": "/Site/0",  # Telescope Site.
-        "telescope": "/Telescope/0",  # Telescope instrument that will be guided by the autoguider.
-        "camera": "/Camera/0",  # Guider camera instrument.
+        "exptime": None,  # Guide exposure (s). None keeps the backend's own setting.
+        "recalibrate": False,  # Recalibrate on every start_guiding, not just when asked.
         "max_acquire_tries": 3,  # Number of tries to find a guiding star.
-        "max_fit_tries": 3,  # Number of tries to acquire the guide star offset before being lost.
         "settle_pixels": 1.5,  # Maximum guide distance (pixels) to consider guiding settled/stable.
         "settle_time": 10.0,  # Minimum time (s) the guider must remain below settle_pixels.
         "settle_timeout": 60.0,  # Maximum time (s) to wait for the guider to settle.
@@ -49,9 +66,15 @@ class Autoguider(Interface):
                             before guiding.
         @type recalibrate: bool
 
-        @param wait: Block until the guider has settled (or failed) instead
-                     of returning right after the sequence is started.
+        @param wait: Block until guiding is established instead of returning
+                     right after the sequence is started. Backends with a
+                     settling notion wait for settle_pixels/settle_time as
+                     well; the others return once corrections have begun.
         @type wait: bool
+
+        Returns the guide star position as [x, y] detector pixels, or None
+        when the backend selected the star itself and does not report it.
+        Callers that need the position should use the star_acquired event.
 
         Raises:
             StarNotFoundException: If no guide star could be acquired.
@@ -74,12 +97,19 @@ class Autoguider(Interface):
     def is_guiding(self):
         """Returns True if a guiding sequence is currently active.
 
+        A backend that keeps the loop running while the star is lost
+        reports True here and GuiderStatus.ERROR from get_status(), so the
+        two can disagree. Use this to decide whether to stop, and
+        get_status() to decide whether guiding is healthy.
+
         @rtype: bool
         """
         raise NotImplementedError()
 
     def get_status(self):
         """Returns the current guider status.
+
+        Must not raise: an unreachable backend reports GuiderStatus.ERROR.
 
         @rtype: GuiderStatus
         """
@@ -95,9 +125,13 @@ class Autoguider(Interface):
 
         @param ra_only: Dither only in right ascension. Uses the
                         'dither_ra_only' configuration value if None.
+                        Backends that do not know the guider's sky
+                        orientation dither along detector x instead, which
+                        is RA only if the guider is aligned.
         @type ra_only: bool
 
         @param wait: Block until the guider has settled at the new position.
+                     Ignored by backends with no settling notion.
         @type wait: bool
 
         Raises:
@@ -108,7 +142,12 @@ class Autoguider(Interface):
     def find_star(self):
         """Attempts to find a guide star in the current field of view.
 
-        Returns the (x, y) position of the selected guide star.
+        Returns the selected guide star as [x, y] detector pixels.
+
+        Whether this raises star_acquired depends on when the backend
+        commits to the star: implementations that choose it themselves
+        raise the event here, those that let the backend choose raise it
+        later, once the backend reports its selection.
 
         Raises:
             StarNotFoundException: If no star is found.
@@ -118,24 +157,59 @@ class Autoguider(Interface):
 
     @event
     def offset_complete(self, offset):
-        """Raised after every offset is complete."""
+        """Raised after every guide correction.
+
+        @param offset: A dict with the keys 'frame' (int), 'dx', 'dy'
+                       (detector pixels), 'ra_distance', 'dec_distance'
+                       (arcsec) and 'snr'. Any key may be missing when the
+                       backend does not report it; consumers must default.
+
+        Only backends that publish per-correction telemetry raise this.
+        """
 
     @event
     def guide_start(self, position):
-        """Raised when a guider sequence starts."""
+        """Raised when a guider sequence starts.
+
+        @param position: Guide star as [x, y] detector pixels, or None if
+                         the backend has not reported its selection yet.
+        """
 
     @event
     def guide_stop(self, state, msg=None):
-        """Raised when a guider sequence stops."""
+        """Raised when a guider sequence stops, including when it stops
+        outside chimera.
+
+        @param state: GuiderStatus.OFF for a normal stop,
+                      GuiderStatus.ABORTED for abort(), GuiderStatus.ERROR
+                      when guiding failed.
+        @param msg: Optional detail, e.g. why guiding stopped.
+        """
 
     @event
     def star_acquired(self, position):
-        """Raised when the guide star is acquired."""
+        """Raised when the guide star is acquired.
+
+        @param position: Guide star as [x, y] detector pixels.
+        """
 
     @event
     def star_lost(self):
-        """Raised when the guide star is lost."""
+        """Raised when the guide star is lost.
+
+        Only backends that can distinguish a lost star from a stopped
+        guider raise this; the rest report GuiderStatus.ERROR instead.
+        """
 
     @event
     def dither_complete(self, offset, status):
-        """Raised when a dither offset finishes settling."""
+        """Raised when a dither offset has been applied.
+
+        @param offset: Applied offset as [dx, dy] detector pixels, or None
+                       if the backend does not report what it used.
+        @param status: GuiderStatus.OK, or ERROR if the dither failed.
+
+        On backends with a settling notion this fires after settling; on
+        the others it fires as soon as the offset is applied, so it does
+        not by itself mean guiding is stable again.
+        """

--- a/src/chimera/interfaces/autoguider.py
+++ b/src/chimera/interfaces/autoguider.py
@@ -11,6 +11,9 @@ from chimera.util.enum import Enum
 class GuiderStatus(Enum):
     OK = "OK"
     GUIDING = "GUIDING"
+    CALIBRATING = "CALIBRATING"
+    SETTLING = "SETTLING"
+    PAUSED = "PAUSED"
     OFF = "OFF"
     ERROR = "ERROR"
     ABORTED = "ABORTED"
@@ -20,17 +23,92 @@ class StarNotFoundException(ChimeraException):
     pass
 
 
+class GuiderException(ChimeraException):
+    pass
+
+
 class Autoguider(Interface):
     __config__ = {
         "site": "/Site/0",  # Telescope Site.
         "telescope": "/Telescope/0",  # Telescope instrument that will be guided by the autoguider.
         "camera": "/Camera/0",  # Guider camera instrument.
         "max_acquire_tries": 3,  # Number of tries to find a guiding star.
-        "max_fit_tries": 3,
-    }  # Number of tries to acquire the guide star offset before being lost.
+        "max_fit_tries": 3,  # Number of tries to acquire the guide star offset before being lost.
+        "settle_pixels": 1.5,  # Maximum guide distance (pixels) to consider guiding settled/stable.
+        "settle_time": 10.0,  # Minimum time (s) the guider must remain below settle_pixels.
+        "settle_timeout": 60.0,  # Maximum time (s) to wait for the guider to settle.
+        "dither_amount": 3.0,  # Default dither amount (pixels).
+        "dither_ra_only": False,  # Dither only in right ascension.
+    }
+
+    def start_guiding(self, recalibrate=False, wait=False):
+        """Start a guiding sequence: acquire a guide star, calibrate if
+        needed and begin sending corrections to the telescope.
+
+        @param recalibrate: Discard the current calibration and recalibrate
+                            before guiding.
+        @type recalibrate: bool
+
+        @param wait: Block until the guider has settled (or failed) instead
+                     of returning right after the sequence is started.
+        @type wait: bool
+
+        Raises:
+            StarNotFoundException: If no guide star could be acquired.
+            GuiderException: If the guider could not be started.
+        """
+        raise NotImplementedError()
+
+    def stop_guiding(self):
+        """Stop the current guiding sequence.
+
+        Raises:
+            GuiderException: If the guider could not be stopped.
+        """
+        raise NotImplementedError()
+
+    def abort(self):
+        """Abort the current guiding sequence as soon as possible."""
+        raise NotImplementedError()
+
+    def is_guiding(self):
+        """Returns True if a guiding sequence is currently active.
+
+        @rtype: bool
+        """
+        raise NotImplementedError()
+
+    def get_status(self):
+        """Returns the current guider status.
+
+        @rtype: GuiderStatus
+        """
+        raise NotImplementedError()
+
+    def dither(self, amount=None, ra_only=None, wait=False):
+        """Offset the guide star lock position by a small random amount
+        and resume guiding at the new position.
+
+        @param amount: Maximum dither offset (pixels). Uses the
+                       'dither_amount' configuration value if None.
+        @type amount: float
+
+        @param ra_only: Dither only in right ascension. Uses the
+                        'dither_ra_only' configuration value if None.
+        @type ra_only: bool
+
+        @param wait: Block until the guider has settled at the new position.
+        @type wait: bool
+
+        Raises:
+            GuiderException: If not guiding or the dither failed.
+        """
+        raise NotImplementedError()
 
     def find_star(self):
         """Attempts to find a guide star in the current field of view.
+
+        Returns the (x, y) position of the selected guide star.
 
         Raises:
             StarNotFoundException: If no star is found.
@@ -57,3 +135,7 @@ class Autoguider(Interface):
     @event
     def star_lost(self):
         """Raised when the guide star is lost."""
+
+    @event
+    def dither_complete(self, offset, status):
+        """Raised when a dither offset finishes settling."""

--- a/src/chimera/interfaces/autoguider.py
+++ b/src/chimera/interfaces/autoguider.py
@@ -25,13 +25,18 @@ class Autoguider(Interface):
         "site": "/Site/0",  # Telescope Site.
         "telescope": "/Telescope/0",  # Telescope instrument that will be guided by the autoguider.
         "camera": "/Camera/0",  # Guider camera instrument.
-        "filterwheel": None,  # Filter wheel instrument, if there is one.
-        "focuser": None,  # Guider camera focuser, if there is one.
-        "autofocus": None,  # Autofocus controller, if there is one.
-        "scheduler": None,  # Scheduler controller, if there is one.
         "max_acquire_tries": 3,  # Number of tries to find a guiding star.
         "max_fit_tries": 3,
     }  # Number of tries to acquire the guide star offset before being lost.
+
+    def find_star(self):
+        """Attempts to find a guide star in the current field of view.
+
+        Raises:
+            StarNotFoundException: If no star is found.
+        """
+
+        raise NotImplementedError()
 
     @event
     def offset_complete(self, offset):
@@ -44,3 +49,11 @@ class Autoguider(Interface):
     @event
     def guide_stop(self, state, msg=None):
         """Raised when a guider sequence stops."""
+
+    @event
+    def star_acquired(self, position):
+        """Raised when the guide star is acquired."""
+
+    @event
+    def star_lost(self):
+        """Raised when the guide star is lost."""

--- a/src/chimera/interfaces/autoguider.py
+++ b/src/chimera/interfaces/autoguider.py
@@ -58,19 +58,19 @@ class Autoguider(Interface):
         "dither_ra_only": False,  # Dither only in right ascension.
     }
 
-    def start_guiding(self, recalibrate=False, wait=False):
+    def start_guiding(
+        self, recalibrate: bool = False, wait: bool = False
+    ) -> list[float] | None:
         """Start a guiding sequence: acquire a guide star, calibrate if
         needed and begin sending corrections to the telescope.
 
         @param recalibrate: Discard the current calibration and recalibrate
                             before guiding.
-        @type recalibrate: bool
 
         @param wait: Block until guiding is established instead of returning
                      right after the sequence is started. Backends with a
                      settling notion wait for settle_pixels/settle_time as
                      well; the others return once corrections have begun.
-        @type wait: bool
 
         Returns the guide star position as [x, y] detector pixels, or None
         when the backend selected the star itself and does not report it.
@@ -82,7 +82,7 @@ class Autoguider(Interface):
         """
         raise NotImplementedError()
 
-    def stop_guiding(self):
+    def stop_guiding(self) -> None:
         """Stop the current guiding sequence.
 
         Raises:
@@ -90,56 +90,54 @@ class Autoguider(Interface):
         """
         raise NotImplementedError()
 
-    def abort(self):
+    def abort(self) -> None:
         """Abort the current guiding sequence as soon as possible."""
         raise NotImplementedError()
 
-    def is_guiding(self):
+    def is_guiding(self) -> bool:
         """Returns True if a guiding sequence is currently active.
 
         A backend that keeps the loop running while the star is lost
         reports True here and GuiderStatus.ERROR from get_status(), so the
         two can disagree. Use this to decide whether to stop, and
         get_status() to decide whether guiding is healthy.
-
-        @rtype: bool
         """
         raise NotImplementedError()
 
-    def get_status(self):
+    def get_status(self) -> GuiderStatus:
         """Returns the current guider status.
 
         Must not raise: an unreachable backend reports GuiderStatus.ERROR.
-
-        @rtype: GuiderStatus
         """
         raise NotImplementedError()
 
-    def dither(self, amount=None, ra_only=None, wait=False):
+    def dither(
+        self,
+        amount: float | None = None,
+        ra_only: bool | None = None,
+        wait: bool = False,
+    ) -> None:
         """Offset the guide star lock position by a small random amount
         and resume guiding at the new position.
 
         @param amount: Maximum dither offset (pixels). Uses the
                        'dither_amount' configuration value if None.
-        @type amount: float
 
         @param ra_only: Dither only in right ascension. Uses the
                         'dither_ra_only' configuration value if None.
                         Backends that do not know the guider's sky
                         orientation dither along detector x instead, which
                         is RA only if the guider is aligned.
-        @type ra_only: bool
 
         @param wait: Block until the guider has settled at the new position.
                      Ignored by backends with no settling notion.
-        @type wait: bool
 
         Raises:
             GuiderException: If not guiding or the dither failed.
         """
         raise NotImplementedError()
 
-    def find_star(self):
+    def find_star(self) -> list[float]:
         """Attempts to find a guide star in the current field of view.
 
         Returns the selected guide star as [x, y] detector pixels.
@@ -156,7 +154,7 @@ class Autoguider(Interface):
         raise NotImplementedError()
 
     @event
-    def offset_complete(self, offset):
+    def offset_complete(self, offset: dict) -> None:
         """Raised after every guide correction.
 
         @param offset: A dict with the keys 'frame' (int), 'dx', 'dy'
@@ -168,7 +166,7 @@ class Autoguider(Interface):
         """
 
     @event
-    def guide_start(self, position):
+    def guide_start(self, position: list[float] | None) -> None:
         """Raised when a guider sequence starts.
 
         @param position: Guide star as [x, y] detector pixels, or None if
@@ -176,7 +174,7 @@ class Autoguider(Interface):
         """
 
     @event
-    def guide_stop(self, state, msg=None):
+    def guide_stop(self, state: GuiderStatus, msg: str | None = None) -> None:
         """Raised when a guider sequence stops, including when it stops
         outside chimera.
 
@@ -187,14 +185,14 @@ class Autoguider(Interface):
         """
 
     @event
-    def star_acquired(self, position):
+    def star_acquired(self, position: list[float]) -> None:
         """Raised when the guide star is acquired.
 
         @param position: Guide star as [x, y] detector pixels.
         """
 
     @event
-    def star_lost(self):
+    def star_lost(self) -> None:
         """Raised when the guide star is lost.
 
         Only backends that can distinguish a lost star from a stopped
@@ -202,7 +200,7 @@ class Autoguider(Interface):
         """
 
     @event
-    def dither_complete(self, offset, status):
+    def dither_complete(self, offset: list[float] | None, status: GuiderStatus) -> None:
         """Raised when a dither offset has been applied.
 
         @param offset: Applied offset as [dx, dy] detector pixels, or None

--- a/tests/chimera/instruments/test_autoguider.py
+++ b/tests/chimera/instruments/test_autoguider.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
+
+import inspect
+import socket
+import threading
+import time
+
+import pytest
+
+from chimera.core.bus import Bus
+from chimera.core.manager import Manager
+from chimera.instruments.fakeautoguider import FakeAutoguider
+from chimera.interfaces.autoguider import Autoguider, GuiderException, GuiderStatus
+
+METHODS = [
+    "start_guiding",
+    "stop_guiding",
+    "abort",
+    "is_guiding",
+    "get_status",
+    "dither",
+    "find_star",
+]
+
+EVENTS = [
+    "offset_complete",
+    "guide_start",
+    "guide_stop",
+    "star_acquired",
+    "star_lost",
+    "dither_complete",
+]
+
+
+def _free_tcp_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture
+def manager():
+    # local fixture on purpose: events need a live bus, and the shared one
+    # in tests/chimera/conftest.py still uses the pre-bus Manager() API
+    bus = Bus(f"tcp://127.0.0.1:{_free_tcp_port()}")
+    bus_thread = threading.Thread(target=bus.run_forever, name="Bus", daemon=True)
+    bus_thread.start()
+    manager = Manager(bus=bus)
+    yield manager
+    manager.shutdown()
+    bus.shutdown()
+    bus_thread.join(timeout=10)
+
+
+@pytest.fixture
+def guider(manager):
+    return manager.add_class(FakeAutoguider, "guider")
+
+
+@pytest.mark.parametrize("name", METHODS)
+def test_signature_matches_the_interface(name):
+    # plugins are written against these signatures; drifting them silently
+    # breaks every out-of-tree implementation
+    assert inspect.signature(getattr(FakeAutoguider, name)) == inspect.signature(
+        getattr(Autoguider, name)
+    )
+
+
+@pytest.mark.parametrize("name", METHODS + EVENTS)
+def test_reference_implementation_is_complete(name):
+    assert callable(getattr(FakeAutoguider(), name))
+
+
+def test_config_keys_resolve():
+    # the metaclass merges the interface __config__ into the plugin's
+    guider = FakeAutoguider()
+    for key in Autoguider.__config__:
+        guider[key]
+
+
+def test_guiding_lifecycle(guider):
+    assert guider.get_status() == GuiderStatus.OFF
+    assert not guider.is_guiding()
+
+    position = guider.start_guiding()
+    assert position == guider.find_star()
+    assert guider.is_guiding()
+    assert guider.get_status() == GuiderStatus.GUIDING
+
+    guider.stop_guiding()
+    assert not guider.is_guiding()
+    assert guider.get_status() == GuiderStatus.OFF
+
+
+def test_abort_reports_aborted(guider):
+    guider.start_guiding()
+    guider.abort()
+    assert guider.get_status() == GuiderStatus.ABORTED
+    assert not guider.is_guiding()
+
+
+def test_dither_requires_guiding():
+    # direct instance: the bus re-raises remote errors as plain Exception,
+    # which would hide the exception type this asserts on
+    with pytest.raises(GuiderException):
+        FakeAutoguider().dither()
+
+
+def test_dither_moves_the_lock_position(guider):
+    guider.start_guiding()
+    before = list(guider.find_star())
+
+    guider.dither(amount=5.0, ra_only=True)
+    after = guider.find_star()
+    assert after[0] == before[0] + 5.0
+    assert after[1] == before[1]  # ra_only leaves the other axis alone
+
+    guider.dither(amount=5.0, ra_only=False)
+    assert guider.find_star()[1] == before[1] + 5.0
+
+
+def test_offsets_are_published_only_while_guiding(guider):
+    offsets = []
+    guider.offset_complete += offsets.append
+
+    guider.control()
+    assert offsets == []  # not guiding yet
+
+    guider.start_guiding()
+    guider.control()
+
+    # events are delivered asynchronously over the bus
+    deadline = time.time() + 10.0
+    while not offsets and time.time() < deadline:
+        time.sleep(0.05)
+    assert len(offsets) == 1
+
+    # the payload the interface documents and chimera-guide --monitor reads
+    assert set(offsets[0]) == {
+        "frame",
+        "dx",
+        "dy",
+        "ra_distance",
+        "dec_distance",
+        "snr",
+    }

--- a/tests/chimera/instruments/test_autoguider.py
+++ b/tests/chimera/instruments/test_autoguider.py
@@ -136,7 +136,7 @@ def test_offsets_are_published_only_while_guiding(guider):
         time.sleep(0.05)
     assert len(offsets) == 1
 
-    # the payload the interface documents and chimera-guide --monitor reads
+    # the payload the interface documents and chimera-guider --monitor reads
     assert set(offsets[0]) == {
         "frame",
         "dx",


### PR DESCRIPTION
Completes the `Autoguider` interface, reconciles it against the two backends that actually implement it, and adds the pieces that make it usable: a reference implementation, a `chimera-guide` CLI, and a scheduler action.

## Reconciliation

The interface was checked against `TheSkyXAutoguider` (chimera-bisque, the more recent of the two) and `PHD2Guiding` (chimera-phd2guiding), plus the CLI and the scheduler. Neither plugin diverges on a method signature, but the contract had dead surface on one side and undeclared requirements on the other.

**Removed** — nothing in either plugin, the fake, the CLI or the scheduler reads them:

- `site`, `telescope`, `camera`. Guiding is performed by the external package, which owns the guide camera and the mount connection itself. Naming chimera instruments here implied a wiring that does not exist.
- `max_fit_tries`.

**Added** — both plugins had independently invented these in their own `__config__`:

- `exptime`, where `None` means "keep whatever the backend is currently set to". That is already PHD2's semantics; TheSkyX's own default of 2 s still overrides it, since the metaclass merges plugin config over the interface's.
- `recalibrate`, as a config default for the existing method argument.

**Documented** — the places where the two backends genuinely disagree, so callers stop assuming the stricter behaviour is portable:

| | TheSkyX | PHD2 |
|---|---|---|
| `wait=True` returns when | guiding has started | the guider has *settled* |
| calibration | separate, chimera-driven, blocking | a flag inside the guide command |
| dither offsets | drawn locally, detector axes | delegated, reported back by PHD2 |
| `dither_complete` | fires when applied | fires after settling |
| `star_lost` | never raised | raised |
| `offset_complete` | never raised | per-correction telemetry |

Also written down: positions and dither amounts are guider **detector pixels** (the only frame both agree on) and `ra_only` degrades to detector x where the sky orientation is unknown; which `GuiderStatus` values every implementation must be able to report (`OFF`, `GUIDING`, `ERROR`) and which are optional; `offset_complete`'s payload keys, which `chimera-guide --monitor` already reads but nothing declared; that `is_guiding()` and `get_status()` may legitimately disagree while the star is lost; and that `start_guiding` returns the star position or `None`.

## Reference implementation and CLI

`FakeAutoguider` acquires instantly at a fixed position and, while guiding, publishes `offset_complete` telemetry so `chimera-guide --monitor` can be exercised in simulation.

`chimera-guide` covers start/stop/abort, dither, find-star, info and monitor.

## Scheduler autoguide action

Lets a program turn guiding on before its science exposures and off afterwards, instead of driving the guider by hand:

```yaml
-   action: autoguide
    enable: True
    recalibrate: False
    wait: True          # block until guiding has settled

-   action: autoguide   # ... after the exposures
    enable: False
```

The handler maps onto `start_guiding`/`stop_guiding`, and `abort()` on the running action aborts the guider. The instrument comes from a new `autoguider` entry in the scheduler's config, defaulting to `/Autoguider/0`.

## Tests

`tests/chimera/instruments/test_autoguider.py` pins every method signature against the interface — out-of-tree plugins break silently when those drift — and covers the guiding lifecycle, abort, dither, and the offset payload keys the CLI reads.

The bus fixture is local rather than the shared one in `tests/chimera/conftest.py`, which still calls the pre-bus `Manager()` API; #244 is what restores that.

## Notes

Rebased onto current master, which dropped the spurious reverts of #248/#249 that the stale branch was showing.