### PR TITLE
scheduler: use the configured site instead of a private Site()

### DIFF
--- a/src/chimera/controllers/scheduler/machine.py
+++ b/src/chimera/controllers/scheduler/machine.py
@@ -6,7 +6,6 @@ from chimera.controllers.scheduler.model import Program, Session
 from chimera.controllers.scheduler.states import State
 from chimera.controllers.scheduler.status import SchedulerStatus
 from chimera.core.exceptions import ProgramExecutionAborted, ProgramExecutionException
-from chimera.core.site import Site
 
 log = logging.getLogger(__name__)
 
@@ -124,7 +123,8 @@ class Machine(threading.Thread):
 
             log.debug(f"[start] {str(task)}")
 
-            site = Site()
+            # the configured site, not a private Site(): one clock system-wide
+            site = self.controller.get_proxy(self.controller["site"])
             now_mjd = site.mjd()
             log.debug("[start] Current MJD is %f", now_mjd)
             if program.start_at:


### PR DESCRIPTION
`Machine._process()` constructed a bare `Site()` — a full ChimeraObject created outside the Manager, never registered, running with default coordinates — just to read `site.mjd()` for the pre-slew wait. It only worked because MJD happens to be location-independent, and it had two real costs:

- the Scheduler's own `site:` config key was silently ignored (decorative);
- the scheduler ran on a **second clock**: any test or simulator that virtualizes time through the configured site (e.g. a time-warping Site used to run a compressed "night" in seconds) could not reach the scheduler's timing decisions.

The fix is one line — the machine already holds the controller, so it can resolve the configured site proxy:

```python
site = self.controller.get_proxy(self.controller["site"])
```

plus the now-unused `Site` import removal. This was the only bare `Site()` instantiation left in the core, so the configured site is now the single time source for the whole system.

Cost: two bus round-trips per program start (negligible against slews/exposures).

Verified with a full-stack integration run (bus + manager + fake instruments + scheduler driven by a time-warped site): the pre-slew wait now follows the configured site's clock.