### PR TITLE
fix(config): apply configured site name to FITS SITE header

### DIFF
--- a/src/chimera/core/chimera_config.py
+++ b/src/chimera/core/chimera_config.py
@@ -141,7 +141,10 @@ class ChimeraConfig:
         assert isinstance(site_config, dict)
 
         site_config["type"] = "Site"
+        # `name` is popped for the URL, but Site also needs it as the SITE header (#231)
+        site_config.setdefault("name", "UFSC")
         site_url, site_conf = self._parse_config(site_config)
+        site_conf["name"] = site_url.name
         self.sites[site_url] = site_conf
 
         for type, object_configs in config.items():

--- a/tests/chimera/core/test_site_config_name.py
+++ b/tests/chimera/core/test_site_config_name.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
+
+import msgspec
+
+from chimera.core.chimera_config import ChimeraConfig
+
+
+def _parse(text):
+    return ChimeraConfig(text, decoder=msgspec.yaml.decode)
+
+
+class TestSiteConfigName:
+    def test_configured_name_reaches_site(self):
+        # `name` must survive as a config value so it shows up in the SITE header (#231)
+        cfg = _parse(
+            """
+            site:
+              name: Swope
+              latitude: "-29:00:00"
+            """
+        )
+        url, conf = next(iter(cfg.sites.items()))
+        assert url.name == "Swope"
+        assert conf["name"] == "Swope"
+
+    def test_default_name_when_omitted(self):
+        cfg = _parse('site:\n  latitude: "-29:00:00"\n')
+        _, conf = next(iter(cfg.sites.items()))
+        assert conf["name"] == "UFSC"


### PR DESCRIPTION
## Problem

Fixes #231. Setting the site `name` in `chimera.config` (e.g. `name: Swope`) had no effect on the FITS header, which always showed:

```
SITE = 'UFSC    ' / Site name (in config)
```

## Cause

`ChimeraConfig._parse_config` pops `name` from every object config to build its URL location (`/Site/<name>`). For the `Site` object, `name` is *also* a config option that `Site.get_metadata` writes to the `SITE` header. Because it was popped and never restored, the `Site` object kept its `__config__` default of `"UFSC"`.

## Fix

Restore `name` into the site's config dict after parsing so it reaches the `Site` object (and therefore the header). The default is preserved when `name` is omitted.

## Tests

Added `tests/chimera/core/test_site_config_name.py` covering both a configured name and the omitted-name default.