### PR TITLE
fix(telescope): write EQUINOX as a numeric epoch

### DIFF
--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -207,7 +207,8 @@ class TelescopeBase(
                 str(Coord.from_d(dec).to_dms()),
                 "Declination of the observed object",
             ),
-            ("EQUINOX", "NOW", "coordinate epoch"),
+            # FITS requires a numeric epoch; coords are J2000/ICRS (see RADESYS) (#228)
+            ("EQUINOX", 2000.0, "coordinate epoch"),
             ("ALT", str(Coord.from_d(alt).to_dms()), "Altitude of the observed object"),
             ("AZ", str(Coord.from_d(az).to_dms()), "Azimuth of the observed object"),
             ("AIRMASS", alt, "Airmass of the observed object"),

--- a/tests/chimera/instruments/test_telescope_equinox.py
+++ b/tests/chimera/instruments/test_telescope_equinox.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
+
+from chimera.instruments.faketelescope import FakeTelescope
+
+
+def test_equinox_is_numeric():
+    # FITS requires EQUINOX to be a float, not the string "NOW" (#228)
+    t = FakeTelescope()
+    t._ra, t._dec, t._alt, t._az = 10.0, -30.0, 45.0, 120.0
+    md = {key: value for key, value, _ in t.get_metadata(None)}
+    assert isinstance(md["EQUINOX"], float)
+    assert md["EQUINOX"] == 2000.0


### PR DESCRIPTION
## Problem

Fixes #228. FITS verification rejects Chimera-generated files:

```
Keyword #42, EQUINOX: value = NOW is not a floating point number. The value is entered as a string.
```

The `EQUINOX` header was emitted as the string `'NOW'`, which violates the FITS standard (the keyword must be numeric).

## Fix

Write `EQUINOX` as `2000.0`. The reported RA/DEC are J2000/ICRS — consistent with the adjacent hard-coded `RADESYS = 'ICRS'` header and the telescope interface's default `epoch=2000`.

## Tests

Added `tests/chimera/instruments/test_telescope_equinox.py` asserting `EQUINOX` is a float.