### PR TITLE
Add temperature_setpoint config to CameraTemperature interface

### DIFF
--- a/src/chimera/interfaces/camera.py
+++ b/src/chimera/interfaces/camera.py
@@ -219,6 +219,13 @@ class CameraTemperature(Camera):
     A camera that supports temperature monitoring and control.
     """
 
+    __config__ = {
+        # Temperature SetPoint (in degrees Celsius) to apply automatically when
+        # the camera starts. Leave as None (the default) to NOT start cooling at
+        # startup; cooling can still be commanded later via start_cooling().
+        "temperature_setpoint": None,
+    }
+
     def start_cooling(self, temp_c):
         """
         Start cooling the camera with SetPoint setted to temp_c.


### PR DESCRIPTION
## Summary

Adds a `temperature_setpoint` configuration directive to the `CameraTemperature` interface, allowing a camera's cooling SetPoint to be applied automatically at startup.

- The directive defaults to `None`, meaning the camera does **not** start cooling automatically at startup — preserving current behaviour for all existing configurations.
- When set to a temperature (in degrees Celsius), a camera implementation can read `self["temperature_setpoint"]` in its `__start__` and begin cooling to that SetPoint.
- Cooling can still be commanded later via `start_cooling()` regardless of this setting.

Because `MetaObject` merges `__config__` across the interface hierarchy, this option becomes available to every `CameraBase` subclass that mixes in `CameraTemperature`.

## Notes

This is the interface-only change. A camera driver implementation (QHY600) consuming this directive lives in the corresponding plugin repository.