### PR TITLE
Fix chimera-sched aborting on point actions with only ra/dec

### DIFF
--- a/src/chimera/cli/sched.py
+++ b/src/chimera/cli/sched.py
@@ -206,12 +206,15 @@ class ChimeraSched(ChimeraCLI):
                         self.out("\tTarget name: %s" % actconfig["name"])
                         act.target_name = actconfig["name"]
 
-                    if (
-                        "offset" not in actconfig
-                        and "dome_az" not in actconfig
-                        and "dome_tracking" not in actconfig
-                        and "name" not in actconfig
-                    ):
+                    has_target = (
+                        ("ra" in actconfig and "dec" in actconfig)
+                        or ("alt" in actconfig and "az" in actconfig)
+                        or "name" in actconfig
+                        or "offset" in actconfig
+                        or "dome_az" in actconfig
+                        or "dome_tracking" in actconfig
+                    )
+                    if not has_target:
                         self.exit(
                             "[%s] Nothing to point at! %s" % (red("ERROR"), actconfig)
                         )


### PR DESCRIPTION
## Problem

Loading a scheduler queue with `chimera-sched --new -f queue.yaml` aborts with

```
[ERROR] Nothing to point at! {'action': 'point', 'ra': '15:39:18', 'dec': '-00:15:30', 'epoch': 'J2000'}
```

for any `point` action that specifies **only** `ra`/`dec` (or `alt`/`az`) — the most basic and common case. The coordinate is parsed correctly (`target_ra_dec` is set, and the loader even prints `Coords: ...`), but the validation guard immediately below wrongly decides there is no target and calls `self.exit()`, killing the whole load.

## Cause

In `_generate_database_yaml`, the guard only treated `offset`, `dome_az`, `dome_tracking`, or `name` as "something to point at". It never included `ra`/`dec` or `alt`/`az`, so a pure-coordinate point action fails the check. The bundled `sample-sched.yaml` only avoided this because its `point` action also carries an `offset:` block.

## Fix

Include `ra`+`dec` and `alt`+`az` in the guard, expressed as a positive `has_target` check. No behavior change for the previously-accepted forms.

## Testing

- A queue whose `point` action has only `ra`/`dec`/`epoch` now loads instead of aborting.
- The existing `offset` / `dome_az` / `dome_tracking` / `name` forms still pass.
- `ruff check` / `ruff format` clean (pre-commit).