### PR TITLE
Focus: HFD catalog columns, ensemble-aware CLI output, and stop() interface

### DIFF
--- a/src/chimera/cli/focus.py
+++ b/src/chimera/cli/focus.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
 
 
+import copy
 import os
 import re
 import sys
@@ -230,6 +231,13 @@ class ChimeraFocus(ChimeraCLI):
         " You can select a focuser range and the size of the step for the sequence."
         " This option is exclusive, you cannot move manually at the same time.",
     )
+    def __abort__(self):
+        # Ctrl-C. copy the proxy: runs from the abort thread, not the action one
+        self.out("\naborting autofocus (returning focuser to start) ... ", end="")
+        if hasattr(self, "autofocus"):
+            copy.copy(self.autofocus).stop()
+        self.out("OK")
+
     def auto(self, options):
         try:
             if not self.autofocus:
@@ -250,27 +258,34 @@ class ChimeraFocus(ChimeraCLI):
                 pass
 
         def step_complete(position, star, filename):
-            self.out(
-                "#%04d (%4d, %4d) FWHM: %8.3f FLUX: %-9.3f (%s)"
-                % (
-                    position,
-                    star["XWIN_IMAGE"],
-                    star["YWIN_IMAGE"],
-                    star["FWHM_IMAGE"],
-                    star["FLUX_BEST"],
-                    star["CHIMERA_FLAGS"],
-                )
-            )
+            # report the ensemble actually fit, not one star's position/flux;
+            # fall back to plain FWHM for controllers without the ensemble fields
+            metric_name = star.get("METRIC_NAME", "FWHM")
+            metric = star.get("METRIC", star.get("FWHM_IMAGE", float("nan")))
+            sigma = star.get("METRIC_SIGMA")
+            nstars = star.get("N_STARS")
+
+            if metric == metric:  # not NaN
+                body = f"{metric_name}: {metric:7.3f}"
+                if sigma is not None and sigma == sigma:
+                    body += f" +/- {sigma:5.3f}"
+                if nstars:
+                    body += f"  ({nstars} stars)"
+            else:
+                body = f"{metric_name}:      --"
+
+            self.out(f"#{position:04d}  {body}  {star['CHIMERA_FLAGS']}")
+
             if ds9:
                 ds9.display_file(filename)
-                ds9.cmd(
-                    "regions command { circle %d %d %d}"
-                    % (
-                        int(star["XWIN_IMAGE"]),
-                        int(star["YWIN_IMAGE"]),
-                        int(star["FWHM_IMAGE"]),
+                x = star.get("XWIN_IMAGE")
+                y = star.get("YWIN_IMAGE")
+                radius = metric if metric == metric else star.get("FWHM_IMAGE")
+                if x and y and radius and radius == radius and radius > 0:
+                    ds9.cmd(
+                        "regions command { circle %d %d %d}"
+                        % (int(x), int(y), int(radius))
                     )
-                )
                 ds9.cmd("zoom to fit")
                 ds9.cmd("scale mode zscale")
 

--- a/src/chimera/interfaces/autofocus.py
+++ b/src/chimera/interfaces/autofocus.py
@@ -39,6 +39,13 @@ class Autofocus(Interface):
         Focus
         """
 
+    def stop(self):
+        """
+        Abort a running focus() ASAP: stop the current exposure and return
+        the focuser to its start position. No-op if nothing is running.
+        Runs concurrently with focus(), so it must not take the focus lock.
+        """
+
     @event
     def step_complete(self, position, star, frame):
         """Raised after every step in the focus sequence with

--- a/src/chimera/util/sexcatalog.py
+++ b/src/chimera/util/sexcatalog.py
@@ -541,6 +541,18 @@ class SExtractorfile:
             "format": "%8.2f",
             "unit": "pixel",
         },
+        "FLUX_RADIUS": {
+            "comment": "Fraction-of-light radii (half-light with PHOT_FLUXFRAC=0.5)",
+            "infunc": float,
+            "format": "%10.3f",
+            "unit": "pixel",
+        },
+        "SNR_WIN": {
+            "comment": "Gaussian-weighted SNR",
+            "infunc": float,
+            "format": "%10.3f",
+            "unit": "",
+        },
         "X2_WORLD": {
             "comment": "Variance along X-WORLD (alpha)",
             "infunc": float,


### PR DESCRIPTION
## Summary

Core-side support for a poor-seeing-resilient autofocus. Companion to
astroufsc/chimera-autofocus#1 — that PR needs the catalog columns and `stop()`
declared here.

## Changes

**`util/sexcatalog.py` — register `FLUX_RADIUS` and `SNR_WIN`**
The catalog parser whitelists column names and raises
`WrongSExtractorfileError` on anything it doesn't know, so requesting
`FLUX_RADIUS` in `PARAMETERS_LIST` currently blows up the whole catalog read.
`FLUX_RADIUS` (half-light radius at the default `PHOT_FLUXFRAC = 0.5`) is what
gives Half-Flux Diameter, the focus metric that stays well-behaved in bad
seeing. `ELLIPTICITY` was already registered.

**`interfaces/autofocus.py` — declare `stop()`**
Abort a running `focus()` ASAP: stop the current exposure and return the
focuser to its start position. Must not take the focus lock, since it has to
run concurrently with the locked `focus()`.

**`cli/focus.py` — report the metric actually being fit**
The per-step line hard-coded `FWHM:` and printed one star's `(x, y)` and
`FLUX`, which are meaningless once the controller fits a robust ensemble over
many stars. It now prints the ensemble metric with its scatter and star count,
degrading gracefully for skipped points and for controllers that don't publish
the ensemble fields:

```
before:  #0320 ( 512,  480) FWHM:    5.821 FLUX: 12000.000 (OK)
after:   #0320  HFD:   5.821 +/- 0.412  (14 stars)  OK
         #0340  HFD:      --  No usable stars at this position.
         #0360  FWHM:   4.732  OK          <- controller without ensemble fields
```
Also adds `__abort__` (Ctrl-C -> `autofocus.stop()`) and guards the DS9 region
against NaN/skipped points. The `__abort__` hook becomes reachable once the
generic CLI Ctrl-C fix lands in its own PR.

## Notes

- The generic `cli/cli.py` fixes (SIGINT handling, request timeouts) were
  dropped from this PR per review; they will be treated in a separate CLI PR
  (some already landed via #262).
- Backward compatible: no existing call sites change. The extra catalog keys are
  only emitted when explicitly requested in `PARAMETERS_LIST`.
- **Not yet validated on-sky** — deployed to the LNA 40 cm (opd-40) and awaiting a
  real focus run. The catalog/interface additions are inert until used, so this
  is safe to merge ahead of that.
