### PR TITLE
Add the missing Operator interface

### DIFF
--- a/src/chimera/interfaces/operator.py
+++ b/src/chimera/interfaces/operator.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
+
+
+from chimera.core.interface import Interface
+
+__all__ = ["Operator"]
+
+
+class Operator(Interface):
+    """A human telescope operator the observatory can ask for a decision.
+
+    The scheduler's operator action blocks on request() until the operator
+    answers, so an implementation may take as long as a person does.
+    """
+
+    def request(self, type: str, msg: str | None = None) -> bool:  # noqa: A002
+        """Request operator intervention and wait for the answer.
+
+        @param type: The kind of request, matching the scheduler action's
+                     'type' field: "confirmation", "input", "alert", etc.
+                     Implementations decide which kinds they can present,
+                     and should reject the ones they cannot.
+        @type  type: str
+
+        @param msg: Message to show the operator.
+        @type  msg: str | None
+
+        @return: True if the operator approved, False otherwise.
+        @rtype: bool
+        """
+        raise NotImplementedError()

--- a/tests/chimera/interfaces/test_operator.py
+++ b/tests/chimera/interfaces/test_operator.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
+
+import inspect
+
+import pytest
+
+from chimera.controllers.scheduler.model import Operator as OperatorAction
+from chimera.interfaces.operator import Operator
+
+
+def test_request_accepts_what_the_scheduler_sends():
+    # OperatorHandler calls op.request(action.type, action.message); this is
+    # the mismatch the missing interface file made impossible to catch
+    inspect.signature(Operator.request).bind(None, "confirmation", "continue?")
+
+
+def test_message_is_optional():
+    inspect.signature(Operator.request).bind(None, "alert")
+
+
+def test_request_field_names_match_the_action():
+    columns = {c.name for c in OperatorAction.__table__.columns}
+    assert {"type", "message"} <= columns
+
+
+def test_unimplemented_by_default():
+    class Incomplete(Operator):
+        pass
+
+    with pytest.raises(NotImplementedError):
+        Incomplete().request("confirmation", "continue?")


### PR DESCRIPTION
The scheduler already ships everything around this interface — an `Operator` action with `type` and `message` fields, an `OperatorHandler` that calls `op.request(action.type, action.message)`, and a default instrument location of `/Operator/0` — but `chimera/interfaces/operator.py` was never committed.

So there is nothing for an implementation to implement against, and nothing that checks the handler's call is even shaped right.

This declares it:

```python
def request(self, type: str, msg: str | None = None) -> bool
```

Blocks until the operator answers, returns whether they approved. `msg` is optional, and the `type` values are tied to the action's own field ("confirmation", "input", "alert", …), with implementations deciding which kinds they can present.

The test binds the handler's exact call against the signature — the mismatch the missing file made impossible to catch — and checks the action still carries the fields the handler reads from it.

No implementation is included: the ones that exist are site-specific (chimera-supervisor answers via Telegram). A `FakeOperator` for simulation would be a reasonable follow-up.