### PR TITLE
Write the actual airmass to the AIRMASS FITS header

### DIFF
--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -15,7 +15,7 @@ from chimera.interfaces.telescope import (
     TelescopeTracking,
 )
 from chimera.util.coord import Coord
-from chimera.util.position import Position
+from chimera.util.position import Position, airmass
 from chimera.util.simbad import simbad_lookup
 
 __all__ = ["TelescopeBase"]
@@ -211,7 +211,7 @@ class TelescopeBase(
             ("EQUINOX", 2000.0, "coordinate epoch"),
             ("ALT", str(Coord.from_d(alt).to_dms()), "Altitude of the observed object"),
             ("AZ", str(Coord.from_d(az).to_dms()), "Azimuth of the observed object"),
-            ("AIRMASS", alt, "Airmass of the observed object"),
+            ("AIRMASS", airmass(alt), "Airmass of the observed object"),
             ("WCSAXES", 2, "wcs dimensionality"),
             ("RADESYS", "ICRS", "frame of reference"),
             (

--- a/src/chimera/util/position.py
+++ b/src/chimera/util/position.py
@@ -9,9 +9,30 @@ try:
 except ImportError:
     from .enum import Enum
 
+import math
+
 import ephem
 
-__all__ = ["Position"]
+__all__ = ["Position", "airmass"]
+
+
+def airmass(alt):
+    """Airmass at a given altitude (float in degrees or Coord), using
+    Kasten & Young (1989).
+
+    Unlike sec(z) this stays finite towards the horizon. Altitudes at or
+    below the horizon are clamped to the horizon value (~37.9): nothing is
+    observable there, and NaN/inf are not valid in a FITS header.
+
+    The published fit returns 0.9997 at the zenith; airmass is by
+    definition >= 1, so the result is clamped there too.
+    """
+    alt_deg = max(float(Coord.from_d(alt).deg), 0.0)
+    return max(
+        1.0,
+        1.0
+        / (math.sin(math.radians(alt_deg)) + 0.50572 * (alt_deg + 6.07995) ** -1.6364),
+    )
 
 
 class Epoch(Enum):

--- a/tests/chimera/util/test_position.py
+++ b/tests/chimera/util/test_position.py
@@ -5,11 +5,30 @@ import pytest
 from dateutil import tz
 
 from chimera.util.coord import Coord
-from chimera.util.position import Epoch, Position
+from chimera.util.position import Epoch, Position, airmass
 
 
 def equal(a, b, e=0.0001):
     return abs(a - b) <= e
+
+
+class TestAirmass:
+    def test_zenith_clamped_to_one(self):
+        assert airmass(90.0) == 1.0
+
+    def test_mid_altitudes_match_sec_z(self):
+        # cross-checked against astropy AltAz.secz on real frames
+        assert equal(airmass(44.07), 1.4360, 1e-3)
+        assert equal(airmass(30.0), 1.9940, 1e-3)
+        assert equal(airmass(10.0), 5.5860, 1e-3)
+
+    def test_horizon_and_below_are_finite(self):
+        horizon = airmass(0.0)
+        assert equal(horizon, 37.920, 1e-2)
+        assert airmass(-10.0) == horizon
+
+    def test_accepts_coord(self):
+        assert airmass(Coord.from_d(90.0)) == 1.0
 
 
 class TestPosition:


### PR DESCRIPTION
## Problem

`TelescopeBase.get_metadata()` writes the **altitude in degrees** into the `AIRMASS` keyword, one line below the `ALT` card that already reports the same number:

```python
("ALT", str(Coord.from_d(alt).to_dms()), "Altitude of the observed object"),
("AZ",  str(Coord.from_d(az).to_dms()),  "Azimuth of the observed object"),
("AIRMASS", alt, "Airmass of the observed object"),   # <- altitude, not airmass
```

The airmass is never computed.

Caught on real frames from the LNA 40 cm: a Landolt field observed at 44.07° altitude (true airmass 1.44) was stamped `AIRMASS = 43.73`. Across a 30-frame sequence the header value correlates with the true altitude at r = 0.999867 (offset −0.34°, i.e. refraction).

The practical damage is that the value is plausible-looking but ~30× too large, so anything consuming it — extinction fits, photometric calibration, ETC work, archive queries — is silently wrong rather than obviously broken. It also misreads as "this field was at airmass 43, unusable" when it was in fact at a perfectly good 1.4.

## Fix

Compute the airmass from the altitude with Kasten & Young (1989).

Two deliberate guards, both about staying valid in a FITS header:

- **At/below the horizon**, clamp to the horizon value (~37.9) instead of returning NaN/inf. `astropy` raises `ValueError: Floating point nan values are not allowed in FITS headers`, so an unguarded formula would raise *while writing the frame* — losing the exposure.
- **At the zenith** the published fit returns 0.9997; airmass is by definition ≥ 1, so the result is clamped there too.

Kasten & Young is used rather than plain `sec(z)` because it stays finite toward the horizon.

The conversion lives in `chimera.util.position` next to the other coordinate transforms (`ra_dec_to_alt_az` and friends) rather than in `telescope.py`: it is pure astronomy math with no telescope state, and plugins that duplicate it today (e.g. chimera-robobs block filtering) can import it from here instead.

## Testing

Cross-checked against `astropy`'s `AltAz.secz` on the real frames above:

| altitude | this fix | astropy sec(z) | diff |
|---|---|---|---|
| 44.07° | 1.4360 | 1.4378 | 0.0017 |
| 41.51° | 1.5068 | 1.5088 | 0.0021 |

Boundary behaviour: zenith → exactly 1.000, 30° → 1.994, 10° → 5.586, horizon → 37.920, below horizon → 37.920 (finite, FITS-valid). Accepts both a float and a `Coord`, matching how `alt` arrives from `get_position_alt_az()`. All of this is now encoded as unit tests in `tests/chimera/util/test_position.py`.

`ruff check` / `ruff format` clean (pre-commit).
