### PR TITLE
Fix BIAS frames taken as 5 s exposures from YAML scheduler queues

### DIFF
--- a/src/chimera/cli/sched.py
+++ b/src/chimera/cli/sched.py
@@ -140,6 +140,24 @@ class ChimeraSched(ChimeraCLI):
         else:
             self._generate_database_basic(options)
 
+    @staticmethod
+    def _calibration_defaults(actconfig):
+        """Values an expose action implies from its image_type but did not spell out.
+
+        Only fills keys the user left out, so an explicit `shutter: OPEN` still
+        gets a light dark.
+        """
+        implied = {}
+        image_type = str(actconfig.get("image_type", "")).upper()
+
+        if image_type == "BIAS" and "exptime" not in actconfig:
+            implied["exptime"] = 0
+
+        if image_type in ("BIAS", "DARK") and "shutter" not in actconfig:
+            implied["shutter"] = "CLOSE"
+
+        return implied
+
     def _generate_database_yaml(self, options):
         with open(options.filename) as stream:
             try:
@@ -270,6 +288,12 @@ class ChimeraSched(ChimeraCLI):
                                     "Could not set attribute %s = %s on action %s"
                                     % (key, actconfig[key], actconfig["action"])
                                 )
+
+                    if actconfig["action"] == "expose":
+                        for key, value in self._calibration_defaults(actconfig).items():
+                            self.out("\t%s: %s (implied by image_type)" % (key, value))
+                            setattr(act, key, value)
+
                 program.actions.append(act)
 
             self.out("")

--- a/src/chimera/controllers/scheduler/sample-sched.yaml
+++ b/src/chimera/controllers/scheduler/sample-sched.yaml
@@ -108,13 +108,13 @@ programs:
             # BIAS
             -   action: expose
                 frames: 10
-                image_type: BIAS  # This will set shutter to close
+                image_type: BIAS  # implies exptime 0 and shutter close
 
             # DARK
             -   action: expose
                 frames: 10
                 exptime: 100
-                image_type: DARK  # This will set shutter to close already
+                image_type: DARK  # implies shutter close
 
             # LIGHT DARK
             -   action: expose

--- a/tests/chimera/cli/test_sched_calibration_defaults.py
+++ b/tests/chimera/cli/test_sched_calibration_defaults.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
+
+from chimera.cli.sched import ChimeraSched
+
+implied = ChimeraSched._calibration_defaults
+
+
+class TestCalibrationDefaults:
+    def test_bias_gets_zero_exptime_and_closed_shutter(self):
+        assert implied({"action": "expose", "frames": 10, "image_type": "BIAS"}) == {
+            "exptime": 0,
+            "shutter": "CLOSE",
+        }
+
+    def test_dark_gets_closed_shutter_but_keeps_exptime(self):
+        assert implied(
+            {"action": "expose", "frames": 10, "exptime": 100, "image_type": "DARK"}
+        ) == {"shutter": "CLOSE"}
+
+    def test_explicit_shutter_wins_so_light_darks_still_work(self):
+        assert (
+            implied(
+                {
+                    "action": "expose",
+                    "exptime": 100,
+                    "shutter": "OPEN",
+                    "image_type": "DARK",
+                }
+            )
+            == {}
+        )
+
+    def test_explicit_bias_exptime_wins(self):
+        assert implied({"action": "expose", "exptime": 2, "image_type": "BIAS"}) == {
+            "shutter": "CLOSE"
+        }
+
+    def test_image_type_is_case_insensitive(self):
+        assert implied({"action": "expose", "image_type": "bias"}) == {
+            "exptime": 0,
+            "shutter": "CLOSE",
+        }
+
+    def test_object_and_flat_are_untouched(self):
+        assert implied({"action": "expose", "image_type": "OBJECT"}) == {}
+        assert implied({"action": "expose", "image_type": "FLAT"}) == {}
+        assert implied({"action": "expose"}) == {}


### PR DESCRIPTION
## The bug

A BIAS block in a YAML scheduler queue produces a **five-second, shutter-open exposure** labelled `IMAGETYP=BIAS`.

`_generate_database_yaml` copies only the keys present in each action dict onto the `Expose` model. Anything omitted falls through to the column defaults in `controllers/scheduler/model.py`:

```python
exptime = Column(Integer, default=5)
shutter = Column(String, default="OPEN")
```

So the calibration block straight out of `sample-sched.yaml` —

```yaml
-   action: expose
    frames: 10
    image_type: BIAS  # This will set shutter to close
```

— lands in the database as `exptime=5, shutter=OPEN`. That comment describes behaviour that was never implemented: nothing in the core, in `ImageRequest`, or in any camera driver derives `shutter` from `image_type`.

The `.txt` parser has always got this right (`sched.py`, `_generate_database_basic`): it forces `exptime = 0` for BIAS and `shutter = "CLOSE"` for anything that is not OBJECT/FLAT. That logic was simply never ported when the YAML format was added, so the two input formats silently disagree.

## Why it matters

The frames are real light exposures, but they carry `IMAGETYP=BIAS`, so downstream reduction picks them up as bias frames and builds a master bias out of five-second sky. On a shutterless detector there is not even a mechanical hint that something is wrong. We hit this on the LNA 40 cm with a QHY: the workaround was a comment in our queue file reminding us that `exptime: 0` is mandatory.

## The fix

Fill the values implied by `image_type` in the YAML path, but only for keys the user left out. Doing it at queue-build time rather than in `ExposeHandler` is deliberate: that is the only place where "the user did not specify a shutter" is distinguishable from "the user asked for OPEN", so the light-dark example in `sample-sched.yaml` (an explicit `shutter: OPEN` on a DARK) keeps working.

Running the fix over the unmodified `sample-sched.yaml`:

```
BIAS  exptime=0     shutter=CLOSE
DARK  exptime=100   shutter=CLOSE
DARK  exptime=100   shutter=OPEN    <- explicit shutter: OPEN, light dark preserved
```

Before the fix the first line read `exptime=5 shutter=OPEN`.

The two misleading comments in `sample-sched.yaml` are corrected to describe what the code now actually does.

## Note for existing deployments

This only affects queue construction. Scheduler databases already on disk keep the values they were built with and must be regenerated (`chimera-sched --new -f <queue>.yaml`) to pick this up.

## Tests

New `tests/chimera/cli/test_sched_calibration_defaults.py`, 6 cases: BIAS implies both values, DARK implies only the shutter, explicit `shutter`/`exptime` win, `image_type` matching is case-insensitive, and OBJECT/FLAT/no-`image_type` are untouched.

`tests/chimera/cli tests/chimera/controllers tests/chimera/util` → 21 passed. The 2 failures in `tests/chimera/util` (`test_image.py::test_extractor`, `test_position.py::test_alt_az_ra_dec`) reproduce identically on unmodified `master` and are unrelated; the full suite does not currently terminate on `master` (see #244).