### PR TITLE
Per-filter focus offsets in FilterWheelBase (replaces chimera-filterfocus)

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -71,9 +71,9 @@ Filter focus offsets
         focus_offsets: "U:-100 B:0 V:0 R:25"
 
 Filters of different optical thickness need different focus positions. Point the wheel at a
-*focuser* and give it a table of *focus_offsets*, in focuser steps, and every filter change moves
-the focuser by the difference between the outgoing and the incoming filter before ``set_filter()``
-returns. Offsets are relative moves, so autofocus results and temperature compensation are
+*focuser* and give it a table of *focus_offsets*, in whatever units that focuser works in (steps,
+microns, ...), and every filter change moves the focuser by the difference between the outgoing
+and the incoming filter before ``set_filter()`` returns. Offsets are relative moves, so autofocus results and temperature compensation are
 preserved. Filters left out of the table (``I`` above) get no offset.
 
 Leave ``focuser`` unset to disable the compensation. If the offset cannot be applied the filter

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -59,6 +59,30 @@ Instruments configuration
 
 Every defined instrument carries a number of configuration options; please refer to the :ref:`Advanced` section for details.
 
+Filter focus offsets
+^^^^^^^^^^^^^^^^^^^^
+::
+
+    filterwheel:
+        name: fake
+        type: FakeFilterWheel
+        filters: "U B V R I"
+        focuser: /FakeFocuser/fake
+        focus_offsets: "U:-100 B:0 V:0 R:25"
+
+Filters of different optical thickness need different focus positions. Point the wheel at a
+*focuser* and give it a table of *focus_offsets*, in focuser steps, and every filter change moves
+the focuser by the difference between the outgoing and the incoming filter before ``set_filter()``
+returns. Offsets are relative moves, so autofocus results and temperature compensation are
+preserved. Filters left out of the table (``I`` above) get no offset.
+
+Leave ``focuser`` unset to disable the compensation. If the offset cannot be applied the filter
+change fails with a ``FocusOffsetException``; set ``focus_offset_required: false`` to only log the
+error and carry on.
+
+This replaces the ``chimera-filterfocus`` plugin, whose ``focus_filters`` and ``focus_difference``
+options map to the ``focus_offsets`` table above.
+
 Controllers Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -66,22 +66,22 @@ Filter focus offsets
     filterwheel:
         name: fake
         type: FakeFilterWheel
-        filters: "U B V R I"
+        filters: [U, B, V, R, I]
         focuser: /FakeFocuser/fake
-        focus_offsets: "U:-100 B:0 V:0 R:25"
+        focus_offsets: {U: -100, B: 0, V: 0, R: 25}
 
 Filters of different optical thickness need different focus positions. Point the wheel at a
-*focuser* and give it a table of *focus_offsets*, in whatever units that focuser works in (steps,
+*focuser* and give it a mapping of *focus_offsets*, in whatever units that focuser works in (steps,
 microns, ...), and every filter change moves the focuser by the difference between the outgoing
 and the incoming filter before ``set_filter()`` returns. Offsets are relative moves, so autofocus results and temperature compensation are
 preserved. Filters left out of the table (``I`` above) get no offset.
 
 Leave ``focuser`` unset to disable the compensation. If the offset cannot be applied the filter
-change fails with a ``FocusOffsetException``; set ``focus_offset_required: false`` to only log the
-error and carry on.
+change fails with a ``FocusOffsetException`` and the exposure never starts, so a focuser that
+cannot reach position surfaces as an error instead of silently unfocused data.
 
 This replaces the ``chimera-filterfocus`` plugin, whose ``focus_filters`` and ``focus_difference``
-options map to the ``focus_offsets`` table above.
+options map to the ``focus_offsets`` mapping above.
 
 Controllers Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/chimera/cli/filter.py
+++ b/src/chimera/cli/filter.py
@@ -6,7 +6,10 @@
 import sys
 
 from chimera.core.version import chimera_version
-from chimera.interfaces.filterwheel import InvalidFilterPositionException
+from chimera.interfaces.filterwheel import (
+    FocusOffsetException,
+    InvalidFilterPositionException,
+)
 
 from .cli import ChimeraCLI, action
 
@@ -57,6 +60,15 @@ class ChimeraFilter(ChimeraCLI):
         for i, f in enumerate(self.wheel.get_filters()):
             self.out(str(f), end="")
         self.out()
+
+        focuser = self.wheel["focuser"]
+        if focuser:
+            offsets = self.wheel.get_focus_offsets()
+            self.out("Focus offsets (%s):" % focuser, end="")
+            for f in self.wheel.get_filters():
+                self.out("%s:%+d" % (f, offsets.get(f, 0)), end="")
+            self.out()
+
         self.out("=" * 40)
 
     @action(
@@ -89,6 +101,8 @@ class ChimeraFilter(ChimeraCLI):
             self.out("OK")
         except InvalidFilterPositionException:
             self.err("ERROR (Invalid Filter)")
+        except FocusOffsetException as e:
+            self.err(f"ERROR (filter changed, focus offset failed: {e})")
 
 
 def main():

--- a/src/chimera/cli/filter.py
+++ b/src/chimera/cli/filter.py
@@ -63,10 +63,10 @@ class ChimeraFilter(ChimeraCLI):
 
         focuser = self.wheel["focuser"]
         if focuser:
-            offsets = self.wheel.get_focus_offsets()
+            offsets = self.wheel["focus_offsets"] or {}
             self.out("Focus offsets (%s):" % focuser, end="")
             for f in self.wheel.get_filters():
-                self.out("%s:%+d" % (f, offsets.get(f, 0)), end="")
+                self.out("%s:%+d" % (f, round(offsets.get(f, 0))), end="")
             self.out()
 
         self.out("=" * 40)

--- a/src/chimera/core/chimera.sample.config
+++ b/src/chimera/core/chimera.sample.config
@@ -27,8 +27,8 @@ camera:
 filterwheel:
   type: FakeFilterWheel
   name: fake
-  filters: "U B V R I"
-  
+  filters: [U, B, V, R, I]
+
 focuser:
   name: fake
   type: FakeFocuser

--- a/src/chimera/core/config.py
+++ b/src/chimera/core/config.py
@@ -130,6 +130,15 @@ class NoneChecker(Checker):
         return value
 
 
+class DictChecker(Checker):
+    def check(self, value):
+        # we MUST return a dict or raise OptionConversionException
+        if isinstance(value, dict):
+            return value
+
+        raise OptionConversionException(f"couldn't convert {type(value)} to dict.")
+
+
 class BoolChecker(Checker):
     def __init__(self):
         Checker.__init__(self)
@@ -352,6 +361,10 @@ class Config:
 
             if isinstance(value, NoneType):
                 options[name] = Option(name, value, NoneChecker())
+                continue
+
+            if isinstance(value, dict):
+                options[name] = Option(name, value, DictChecker())
                 continue
 
             # For list and tuple we use the first element as default option.

--- a/src/chimera/instruments/fakefilterwheel.py
+++ b/src/chimera/instruments/fakefilterwheel.py
@@ -2,9 +2,7 @@
 # SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
 
 
-from chimera.core.lock import lock
 from chimera.instruments.filterwheel import FilterWheelBase
-from chimera.interfaces.filterwheel import InvalidFilterPositionException
 
 
 class FakeFilterWheel(FilterWheelBase):
@@ -16,13 +14,5 @@ class FakeFilterWheel(FilterWheelBase):
     def get_filter(self):
         return self._get_filter_name(self._last_filter)
 
-    @lock
-    def set_filter(self, filter):
-        filter_name = str(filter)
-
-        if filter_name not in self.get_filters():
-            raise InvalidFilterPositionException(f"Invalid filter {filter}.")
-
-        self.filter_change(filter, self._get_filter_name(self._last_filter))
-
-        self._last_filter = self._get_filter_position(filter)
+    def _set_filter(self, filter_name):
+        self._last_filter = self._get_filter_position(filter_name)

--- a/src/chimera/instruments/filterwheel.py
+++ b/src/chimera/instruments/filterwheel.py
@@ -3,23 +3,156 @@
 
 
 from chimera.core.chimeraobject import ChimeraObject
+from chimera.core.exceptions import ChimeraException
 from chimera.core.lock import lock
-from chimera.interfaces.filterwheel import FilterWheel, InvalidFilterPositionException
+from chimera.interfaces.filterwheel import (
+    FilterWheel,
+    FocusOffsetException,
+    InvalidFilterPositionException,
+)
 
 
 class FilterWheelBase(ChimeraObject, FilterWheel):
     def __init__(self):
         ChimeraObject.__init__(self)
 
+        # parsed lazily: __config__ is only populated after __init__, and
+        # drivers are not required to chain up to our __start__
+        self._focus_offsets = None
+        # offset currently on the focuser; None until the first filter change
+        self._applied_focus_offset = None
+
+        # here rather than in __start__: legacy drivers override __start__
+        # without chaining up, and they are exactly the ones being warned about
+        self._warn_if_set_filter_overridden()
+
+    def __start__(self):
+        self.get_focus_offsets()  # fail early on a malformed offset table
+
+    def _set_filter(self, filter_name):
+        """
+        Move the wheel to filter_name. Called with the object monitor held and
+        with filter_name already validated against the configured filters.
+
+        Drivers implement this; the focus offset, the C{filter_change} event
+        and the validation are handled by L{set_filter}.
+        """
+        raise NotImplementedError()
+
     @lock
     def set_filter(self, filter):
-        raise NotImplementedError()
+        filter_name = str(filter)
+
+        if filter_name not in self.get_filters():
+            raise InvalidFilterPositionException(f"Invalid filter {filter}.")
+
+        old_filter = self._current_filter_or_none()
+
+        self._set_filter(filter_name)
+
+        try:
+            self._apply_focus_offset(filter_name, old_filter)
+        finally:
+            self.filter_change(filter_name, old_filter)
+
+        return True
 
     def get_filter(self):
         raise NotImplementedError()
 
     def get_filters(self):
         return self["filters"].split()
+
+    def get_focus_offsets(self):
+        if self._focus_offsets is None:
+            self._focus_offsets = self._parse_focus_offsets()
+        return dict(self._focus_offsets)
+
+    def _current_filter_or_none(self):
+        try:
+            return self.get_filter()
+        except ChimeraException:
+            # position unknown, e.g. a wheel that hasn't homed since power-up
+            return None
+
+    def _parse_focus_offsets(self):
+        offsets = {}
+
+        for entry in str(self["focus_offsets"] or "").split():
+            name, _, value = entry.partition(":")
+            try:
+                offsets[name] = int(round(float(value)))
+            except ValueError:
+                raise FocusOffsetException(
+                    f"Invalid focus_offsets entry '{entry}', expected 'FILTER:OFFSET'."
+                )
+
+        unknown = sorted(set(offsets) - set(self.get_filters()))
+        if unknown:
+            raise FocusOffsetException(
+                f"focus_offsets names filters that are not on this wheel: {unknown}."
+            )
+
+        return offsets
+
+    def _apply_focus_offset(self, new_filter, old_filter):
+        if not self["focuser"]:
+            return
+
+        offsets = self.get_focus_offsets()
+        target = offsets.get(new_filter, 0)
+
+        applied = self._applied_focus_offset
+        if applied is None:
+            # first change after start-up: assume the focuser already sits
+            # where the outgoing filter wants it, so only move the difference
+            applied = offsets.get(old_filter, 0)
+
+        delta = target - applied
+
+        if delta:
+            try:
+                focuser = self.get_proxy(self["focuser"])
+                if delta < 0:
+                    self.log.debug(
+                        f"Moving focuser {-delta} steps IN for filter {new_filter}"
+                    )
+                    focuser.move_in(-delta)
+                else:
+                    self.log.debug(
+                        f"Moving focuser {delta} steps OUT for filter {new_filter}"
+                    )
+                    focuser.move_out(delta)
+            except Exception as e:
+                # leave _applied_focus_offset alone: it still describes the
+                # last offset we know reached the focuser
+                message = (
+                    f"Could not apply {delta} step focus offset for filter "
+                    f"{new_filter}: {e}"
+                )
+                if self["focus_offset_required"]:
+                    raise FocusOffsetException(message) from e
+                self.log.error(message)
+                return
+
+        self._applied_focus_offset = target
+
+    def _warn_if_set_filter_overridden(self):
+        """
+        Drivers written against chimera <= 0.2 implement set_filter() instead
+        of _set_filter(), which bypasses the focus offset entirely.
+        """
+        for cls in type(self).__mro__:
+            if cls is FilterWheelBase:
+                return
+            if "set_filter" in cls.__dict__:
+                self.log.warning(
+                    f"{cls.__name__} overrides set_filter(): focus offsets will "
+                    f"NOT be applied. Rename it to _set_filter() and drop the "
+                    f"filter validation and the filter_change() call, which "
+                    f"FilterWheelBase now does."
+                )
+                return
 
     def _get_filter_name(self, index):
         try:
@@ -31,7 +164,22 @@ class FilterWheelBase(ChimeraObject, FilterWheel):
         return self.get_filters().index(name)
 
     def get_metadata(self, request):
-        return [
+        md = self.get_metadata_override(request)
+        if md is not None:
+            return md
+
+        md = [
             ("FWHEEL", str(self["filter_wheel_model"]), "Filter Wheel Model"),
             ("FILTER", str(self.get_filter()), "Filter used for this observation"),
         ]
+
+        if self["focuser"] and self._applied_focus_offset is not None:
+            md += [
+                (
+                    "FOCUSOFF",
+                    self._applied_focus_offset,
+                    "Filter focus offset applied [steps]",
+                )
+            ]
+
+        return md

--- a/src/chimera/instruments/filterwheel.py
+++ b/src/chimera/instruments/filterwheel.py
@@ -115,19 +115,19 @@ class FilterWheelBase(ChimeraObject, FilterWheel):
                 focuser = self.get_proxy(self["focuser"])
                 if delta < 0:
                     self.log.debug(
-                        f"Moving focuser {-delta} steps IN for filter {new_filter}"
+                        f"Moving focuser {-delta} IN for filter {new_filter}"
                     )
                     focuser.move_in(-delta)
                 else:
                     self.log.debug(
-                        f"Moving focuser {delta} steps OUT for filter {new_filter}"
+                        f"Moving focuser {delta} OUT for filter {new_filter}"
                     )
                     focuser.move_out(delta)
             except Exception as e:
                 # leave _applied_focus_offset alone: it still describes the
                 # last offset we know reached the focuser
                 message = (
-                    f"Could not apply {delta} step focus offset for filter "
+                    f"Could not apply a {delta} focus offset for filter "
                     f"{new_filter}: {e}"
                 )
                 if self["focus_offset_required"]:
@@ -178,7 +178,7 @@ class FilterWheelBase(ChimeraObject, FilterWheel):
                 (
                     "FOCUSOFF",
                     self._applied_focus_offset,
-                    "Filter focus offset applied [steps]",
+                    "Filter focus offset applied [focuser units]",
                 )
             ]
 

--- a/src/chimera/instruments/filterwheel.py
+++ b/src/chimera/instruments/filterwheel.py
@@ -55,11 +55,7 @@ class FilterWheelBase(ChimeraObject, FilterWheel):
         raise NotImplementedError()
 
     def get_filters(self):
-        filters = self["filters"] or []
-        # tolerate the old space-separated string form
-        if isinstance(filters, str):
-            filters = filters.split()
-        return list(filters)
+        return list(self["filters"] or [])
 
     def _current_filter_or_none(self):
         try:

--- a/src/chimera/instruments/filterwheel.py
+++ b/src/chimera/instruments/filterwheel.py
@@ -3,7 +3,6 @@
 
 
 from chimera.core.chimeraobject import ChimeraObject
-from chimera.core.exceptions import ChimeraException
 from chimera.core.lock import lock
 from chimera.interfaces.filterwheel import (
     FilterWheel,
@@ -40,7 +39,7 @@ class FilterWheelBase(ChimeraObject, FilterWheel):
         if filter_name not in self.get_filters():
             raise InvalidFilterPositionException(f"Invalid filter {filter}.")
 
-        old_filter = self._current_filter_or_none()
+        old_filter = self.get_filter()
 
         self._set_filter(filter_name)
 
@@ -56,13 +55,6 @@ class FilterWheelBase(ChimeraObject, FilterWheel):
 
     def get_filters(self):
         return list(self["filters"] or [])
-
-    def _current_filter_or_none(self):
-        try:
-            return self.get_filter()
-        except ChimeraException:
-            # position unknown, e.g. a wheel that hasn't homed since power-up
-            return None
 
     def _validate_focus_offsets(self):
         offsets = self["focus_offsets"] or {}
@@ -128,12 +120,11 @@ class FilterWheelBase(ChimeraObject, FilterWheel):
             ("FILTER", str(self.get_filter()), "Filter used for this observation"),
         ]
 
-        current = self._current_filter_or_none()
-        if self["focuser"] and current is not None:
+        if self["focuser"]:
             md += [
                 (
                     "FOCUSOFF",
-                    self._focus_offsets.get(current, 0),
+                    self._focus_offsets.get(self.get_filter(), 0),
                     "Filter focus offset applied [focuser units]",
                 )
             ]

--- a/src/chimera/instruments/filterwheel.py
+++ b/src/chimera/instruments/filterwheel.py
@@ -16,18 +16,12 @@ class FilterWheelBase(ChimeraObject, FilterWheel):
     def __init__(self):
         ChimeraObject.__init__(self)
 
-        # parsed lazily: __config__ is only populated after __init__, and
-        # drivers are not required to chain up to our __start__
-        self._focus_offsets = None
-        # offset currently on the focuser; None until the first filter change
-        self._applied_focus_offset = None
-
-        # here rather than in __start__: legacy drivers override __start__
-        # without chaining up, and they are exactly the ones being warned about
-        self._warn_if_set_filter_overridden()
+        # validated at __start__; empty until then so get_metadata() before
+        # start-up (and drivers that skip our __start__) still work
+        self._focus_offsets = {}
 
     def __start__(self):
-        self.get_focus_offsets()  # fail early on a malformed offset table
+        self._focus_offsets = self._validate_focus_offsets()
 
     def _set_filter(self, filter_name):
         """
@@ -61,12 +55,11 @@ class FilterWheelBase(ChimeraObject, FilterWheel):
         raise NotImplementedError()
 
     def get_filters(self):
-        return self["filters"].split()
-
-    def get_focus_offsets(self):
-        if self._focus_offsets is None:
-            self._focus_offsets = self._parse_focus_offsets()
-        return dict(self._focus_offsets)
+        filters = self["filters"] or []
+        # tolerate the old space-separated string form
+        if isinstance(filters, str):
+            filters = filters.split()
+        return list(filters)
 
     def _current_filter_or_none(self):
         try:
@@ -75,84 +68,50 @@ class FilterWheelBase(ChimeraObject, FilterWheel):
             # position unknown, e.g. a wheel that hasn't homed since power-up
             return None
 
-    def _parse_focus_offsets(self):
-        offsets = {}
+    def _validate_focus_offsets(self):
+        offsets = self["focus_offsets"] or {}
 
-        for entry in str(self["focus_offsets"] or "").split():
-            name, _, value = entry.partition(":")
+        normalized = {}
+        for name, value in offsets.items():
             try:
-                offsets[name] = int(round(float(value)))
-            except ValueError:
+                normalized[name] = int(round(float(value)))
+            except (TypeError, ValueError):
                 raise FocusOffsetException(
-                    f"Invalid focus_offsets entry '{entry}', expected 'FILTER:OFFSET'."
+                    f"Invalid focus_offsets value for filter '{name}': {value!r}."
                 )
 
-        unknown = sorted(set(offsets) - set(self.get_filters()))
+        unknown = sorted(set(normalized) - set(self.get_filters()))
         if unknown:
             raise FocusOffsetException(
                 f"focus_offsets names filters that are not on this wheel: {unknown}."
             )
 
-        return offsets
+        return normalized
 
     def _apply_focus_offset(self, new_filter, old_filter):
         if not self["focuser"]:
             return
 
-        offsets = self.get_focus_offsets()
-        target = offsets.get(new_filter, 0)
+        offsets = self._focus_offsets
+        # relative move: only the difference between the outgoing and the
+        # incoming filter. An unknown/unhomed old_filter contributes no offset.
+        delta = offsets.get(new_filter, 0) - offsets.get(old_filter, 0)
 
-        applied = self._applied_focus_offset
-        if applied is None:
-            # first change after start-up: assume the focuser already sits
-            # where the outgoing filter wants it, so only move the difference
-            applied = offsets.get(old_filter, 0)
+        if not delta:
+            return
 
-        delta = target - applied
-
-        if delta:
-            try:
-                focuser = self.get_proxy(self["focuser"])
-                if delta < 0:
-                    self.log.debug(
-                        f"Moving focuser {-delta} IN for filter {new_filter}"
-                    )
-                    focuser.move_in(-delta)
-                else:
-                    self.log.debug(
-                        f"Moving focuser {delta} OUT for filter {new_filter}"
-                    )
-                    focuser.move_out(delta)
-            except Exception as e:
-                # leave _applied_focus_offset alone: it still describes the
-                # last offset we know reached the focuser
-                message = (
-                    f"Could not apply a {delta} focus offset for filter "
-                    f"{new_filter}: {e}"
-                )
-                if self["focus_offset_required"]:
-                    raise FocusOffsetException(message) from e
-                self.log.error(message)
-                return
-
-        self._applied_focus_offset = target
-
-    def _warn_if_set_filter_overridden(self):
-        """
-        Drivers written against chimera <= 0.2 implement set_filter() instead
-        of _set_filter(), which bypasses the focus offset entirely.
-        """
-        for cls in type(self).__mro__:
-            if cls is FilterWheelBase:
-                return
-            if "set_filter" in cls.__dict__:
-                self.log.warning(
-                    f"{cls.__name__} overrides set_filter(): focus offsets will "
-                    f"NOT be applied. Rename it to _set_filter() and drop the "
-                    f"filter validation and the filter_change() call, which "
-                    f"FilterWheelBase now does."
-                )
-                return
+        try:
+            focuser = self.get_proxy(self["focuser"])
+            if delta < 0:
+                self.log.debug(f"Moving focuser {-delta} IN for filter {new_filter}")
+                focuser.move_in(-delta)
+            else:
+                self.log.debug(f"Moving focuser {delta} OUT for filter {new_filter}")
+                focuser.move_out(delta)
+        except Exception as e:
+            raise FocusOffsetException(
+                f"Could not apply a {delta} focus offset for filter {new_filter}: {e}"
+            ) from e
 
     def _get_filter_name(self, index):
         try:
@@ -173,11 +132,12 @@ class FilterWheelBase(ChimeraObject, FilterWheel):
             ("FILTER", str(self.get_filter()), "Filter used for this observation"),
         ]
 
-        if self["focuser"] and self._applied_focus_offset is not None:
+        current = self._current_filter_or_none()
+        if self["focuser"] and current is not None:
             md += [
                 (
                     "FOCUSOFF",
-                    self._applied_focus_offset,
+                    self._focus_offsets.get(current, 0),
                     "Filter focus offset applied [focuser units]",
                 )
             ]

--- a/src/chimera/interfaces/filterwheel.py
+++ b/src/chimera/interfaces/filterwheel.py
@@ -11,6 +11,12 @@ class InvalidFilterPositionException(ChimeraException):
     pass
 
 
+class FocusOffsetException(ChimeraException):
+    """
+    Raised when the focus offset of a filter could not be applied.
+    """
+
+
 class FilterWheel(Interface):
     """
     An interface for electromechanical filter wheels.
@@ -21,14 +27,31 @@ class FilterWheel(Interface):
         "device": "/dev/ttyS0",
         "filter_wheel_model": "Fake Filters Inc.",
         "filters": "R G B LUNAR CLEAR",  # space separated filter names (in position order)
+        # Focuser used to compensate for the different optical thickness of
+        # each filter. Leave as None (the default) to disable compensation.
+        "focuser": None,
+        # Focus offsets in focuser steps, as "FILTER:OFFSET" pairs, e.g.
+        # "U:-100 B:0 V:0". Filters absent from the table get no offset.
+        "focus_offsets": "",
+        # Fail the filter change when the focus offset cannot be applied. Set
+        # to false to only log the error and carry on. Only real YAML booleans
+        # work here, not the strings "true"/"false" (astroufsc/chimera#258).
+        "focus_offset_required": True,
     }
 
     def set_filter(self, filter):
         """
-        Set the current filter.
+        Set the current filter, applying the configured focus offset (if any)
+        before returning.
 
         @param filter: The filter to use.
         @type  filter: str
+
+        @raises InvalidFilterPositionException: When the filter is not
+        available on this wheel.
+
+        @raises FocusOffsetException: When the focus offset could not be
+        applied and C{focus_offset_required} is set.
 
         @rtype: None
         """
@@ -47,6 +70,15 @@ class FilterWheel(Interface):
 
         @return: Tuple of all filters available.
         @rtype: tuple
+        """
+
+    def get_focus_offsets(self):
+        """
+        Return the configured focus offsets, in focuser steps, keyed by filter
+        name. Filters with no configured offset are absent from the mapping.
+
+        @return: Focus offset of each filter.
+        @rtype: dict
         """
 
     @event

--- a/src/chimera/interfaces/filterwheel.py
+++ b/src/chimera/interfaces/filterwheel.py
@@ -30,7 +30,8 @@ class FilterWheel(Interface):
         # Focuser used to compensate for the different optical thickness of
         # each filter. Leave as None (the default) to disable compensation.
         "focuser": None,
-        # Focus offsets in focuser steps, as "FILTER:OFFSET" pairs, e.g.
+        # Focus offsets in the focuser's own units (steps, microns, ...),
+        # as "FILTER:OFFSET" pairs, e.g.
         # "U:-100 B:0 V:0". Filters absent from the table get no offset.
         "focus_offsets": "",
         # Fail the filter change when the focus offset cannot be applied. Set
@@ -74,7 +75,8 @@ class FilterWheel(Interface):
 
     def get_focus_offsets(self):
         """
-        Return the configured focus offsets, in focuser steps, keyed by filter
+        Return the configured focus offsets, in the focuser's own units,
+        keyed by filter
         name. Filters with no configured offset are absent from the mapping.
 
         @return: Focus offset of each filter.

--- a/src/chimera/interfaces/filterwheel.py
+++ b/src/chimera/interfaces/filterwheel.py
@@ -26,18 +26,15 @@ class FilterWheel(Interface):
     __config__ = {
         "device": "/dev/ttyS0",
         "filter_wheel_model": "Fake Filters Inc.",
-        "filters": "R G B LUNAR CLEAR",  # space separated filter names (in position order)
+        # Filter names in position order, as a list: ["R", "G", "B"].
+        "filters": [],
         # Focuser used to compensate for the different optical thickness of
         # each filter. Leave as None (the default) to disable compensation.
         "focuser": None,
         # Focus offsets in the focuser's own units (steps, microns, ...),
-        # as "FILTER:OFFSET" pairs, e.g.
-        # "U:-100 B:0 V:0". Filters absent from the table get no offset.
-        "focus_offsets": "",
-        # Fail the filter change when the focus offset cannot be applied. Set
-        # to false to only log the error and carry on. Only real YAML booleans
-        # work here, not the strings "true"/"false" (astroufsc/chimera#258).
-        "focus_offset_required": True,
+        # keyed by filter name, e.g. {"U": -100, "B": 0, "V": 0}. Filters
+        # absent from the table get no offset.
+        "focus_offsets": {},
     }
 
     def set_filter(self, filter):
@@ -52,7 +49,7 @@ class FilterWheel(Interface):
         available on this wheel.
 
         @raises FocusOffsetException: When the focus offset could not be
-        applied and C{focus_offset_required} is set.
+        applied.
 
         @rtype: None
         """
@@ -71,16 +68,6 @@ class FilterWheel(Interface):
 
         @return: Tuple of all filters available.
         @rtype: tuple
-        """
-
-    def get_focus_offsets(self):
-        """
-        Return the configured focus offsets, in the focuser's own units,
-        keyed by filter
-        name. Filters with no configured offset are absent from the mapping.
-
-        @return: Focus offset of each filter.
-        @rtype: dict
         """
 
     @event

--- a/tests/chimera/core/test_config.py
+++ b/tests/chimera/core/test_config.py
@@ -141,6 +141,22 @@ class TestConfig:
             with pytest.raises(OptionConversionException):
                 c.__setitem__("key_range", i)
 
+    def test_dict(self):
+        c = Config({"key_dict": {"U": -100, "B": 0}})
+
+        # default is kept as-is
+        assert c.__getitem__("key_dict") == {"U": -100, "B": 0}
+
+        # any dict is accepted (including empty)
+        for value in ({"R": 25}, {}):
+            assert c.__setitem__("key_dict", value) is not False
+            assert c.__getitem__("key_dict") == value
+
+        # non-dict values are rejected
+        for value in ("U:-100", 3, ["U", "B"]):
+            with pytest.raises(OptionConversionException):
+                c.__setitem__("key_dict", value)
+
     def test_iter(self):
         d = {
             "device": "/dev/ttyS0",

--- a/tests/chimera/instruments/test_filterwheel.py
+++ b/tests/chimera/instruments/test_filterwheel.py
@@ -304,8 +304,7 @@ class TestFilterWheelFocusOffsetErrors:
         assert wheel.get_filter() == "V"
         assert events == [("V", "U")]
         assert any(
-            "Could not apply 100 step focus offset" in message
-            for message in chimera_log
+            "Could not apply a 100 focus offset" in message for message in chimera_log
         )
 
     def test_malformed_offsets_fail_at_startup(self, make_wheel, focuser):

--- a/tests/chimera/instruments/test_filterwheel.py
+++ b/tests/chimera/instruments/test_filterwheel.py
@@ -1,11 +1,17 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
 
+import logging
 import time
 
 import pytest
 
+from chimera.core.exceptions import ChimeraException, ObjectNotFoundException
 from chimera.instruments.fakefilterwheel import FakeFilterWheel
+from chimera.interfaces.filterwheel import (
+    FocusOffsetException,
+    InvalidFilterPositionException,
+)
 
 # hack for event triggering asserts
 fired_events = {}
@@ -47,3 +53,288 @@ class TestFakeFilterWheel:
         filters = filterwheel.get_filters()
 
         assert isinstance(filters, tuple) or isinstance(filters, list)
+
+
+# ---------------------------------------------------------------------------
+# Per-filter focus offsets (unit level, no bus): FilterWheelBase.set_filter
+# applies the configured offset through the focuser role.
+# ---------------------------------------------------------------------------
+
+FILTERS = "U B V R I"
+# I is deliberately left out: filters with no entry get no offset
+FOCUS_OFFSETS = "U:-100 B:0 V:0 R:25"
+
+FOCUSER_LOCATION = "/FakeFocuser/0"
+
+
+class FakeFocuser:
+    """Just enough focuser to record the relative moves it is asked for."""
+
+    def __init__(self):
+        self.position = 3500
+        self.moves = []
+
+    def move_in(self, n):
+        self.moves.append(-n)
+        self.position -= n
+
+    def move_out(self, n):
+        self.moves.append(+n)
+        self.position += n
+
+
+@pytest.fixture
+def events(monkeypatch):
+    """filter_change goes through the bus, which we don't have here."""
+    fired = []
+    monkeypatch.setattr(
+        FakeFilterWheel,
+        "filter_change",
+        lambda self, new, old: fired.append((new, old)),
+        raising=False,
+    )
+    return fired
+
+
+@pytest.fixture
+def focuser():
+    return FakeFocuser()
+
+
+@pytest.fixture
+def chimera_log():
+    """chimera's logger does not propagate to the root one, so caplog is blind."""
+    messages = []
+
+    class Recorder(logging.Handler):
+        def emit(self, record):
+            messages.append(record.getMessage())
+
+    handler = Recorder()
+    logger = logging.getLogger("chimera")
+    logger.addHandler(handler)
+    try:
+        yield messages
+    finally:
+        logger.removeHandler(handler)
+
+
+@pytest.fixture
+def make_wheel(monkeypatch, events):
+    def factory(focuser_proxy=None, **config):
+        wheel = FakeFilterWheel()
+        wheel["filters"] = FILTERS
+        for key, value in config.items():
+            wheel[key] = value
+
+        if focuser_proxy is not None:
+            monkeypatch.setattr(wheel, "get_proxy", lambda url: focuser_proxy)
+
+        wheel.__start__()
+        return wheel
+
+    return factory
+
+
+@pytest.fixture
+def wheel(make_wheel, focuser):
+    return make_wheel(
+        focuser_proxy=focuser,
+        focuser=FOCUSER_LOCATION,
+        focus_offsets=FOCUS_OFFSETS,
+    )
+
+
+#
+# filter wheel basics
+#
+class TestFilterWheel:
+    def test_get_filters(self, make_wheel):
+        assert make_wheel().get_filters() == FILTERS.split()
+
+    def test_set_filter_moves_and_fires_event(self, make_wheel, events):
+        wheel = make_wheel()
+
+        assert wheel.set_filter("B")
+        assert wheel.get_filter() == "B"
+        assert events == [("B", "U")]
+
+        wheel.set_filter("R")
+        assert wheel.get_filter() == "R"
+        assert events == [("B", "U"), ("R", "B")]
+
+    def test_set_invalid_filter_raises(self, make_wheel):
+        with pytest.raises(InvalidFilterPositionException):
+            make_wheel().set_filter("Z")
+
+    def test_no_focus_offsets_by_default(self, make_wheel):
+        assert make_wheel().get_focus_offsets() == {}
+
+    def test_offsets_without_a_focuser_are_ignored(self, make_wheel, focuser):
+        # no `focuser` configured, so nothing to compensate with
+        wheel = make_wheel(focuser_proxy=focuser, focus_offsets=FOCUS_OFFSETS)
+
+        wheel.set_filter("V")
+
+        assert focuser.moves == []
+
+    def test_metadata(self, make_wheel):
+        wheel = make_wheel()
+        wheel.set_filter("V")
+
+        keywords = dict((key, value) for key, value, _ in wheel.get_metadata(None))
+
+        assert keywords["FILTER"] == "V"
+        assert "FOCUSOFF" not in keywords
+
+
+#
+# focus offsets
+#
+class TestFilterWheelFocusOffsets:
+    """
+    The focuser move happens inside set_filter(), so every assertion on the
+    focuser position right after set_filter() returns is also asserting that
+    the offset was applied synchronously.
+    """
+
+    def test_get_focus_offsets(self, wheel):
+        assert wheel.get_focus_offsets() == {"U": -100, "B": 0, "V": 0, "R": 25}
+
+    def test_offset_applied_on_filter_change(self, wheel, focuser):
+        # the wheel starts on U, so the focuser is assumed to already carry
+        # U's offset: moving to V has to back those -100 steps out
+        start = focuser.position
+
+        wheel.set_filter("V")
+        assert focuser.position == start + 100
+
+        wheel.set_filter("R")
+        assert focuser.position == start + 125
+
+        wheel.set_filter("U")
+        assert focuser.position == start
+
+    def test_filter_without_offset_does_not_move(self, wheel, focuser):
+        wheel.set_filter("V")
+        focuser.moves.clear()
+
+        wheel.set_filter("I")
+
+        assert focuser.moves == []
+
+    def test_same_offset_does_not_move(self, wheel, focuser):
+        wheel.set_filter("V")
+        focuser.moves.clear()
+
+        wheel.set_filter("B")  # B and V share the same offset
+
+        assert focuser.moves == []
+
+    def test_no_drift_over_repeated_cycles(self, wheel, focuser):
+        start = focuser.position
+
+        for _ in range(5):
+            for filter in wheel.get_filters():
+                wheel.set_filter(filter)
+
+        wheel.set_filter("U")
+        assert focuser.position == start
+
+    def test_unknown_previous_filter(self, wheel, focuser, monkeypatch):
+        # a wheel that has not homed since power-up cannot report its current
+        # filter (chimera-fli raises here); the offset is applied from zero
+        def position_unknown():
+            raise ChimeraException("wheel has not homed yet")
+
+        monkeypatch.setattr(wheel, "get_filter", position_unknown)
+        start = focuser.position
+
+        wheel.set_filter("U")
+
+        assert focuser.position == start - 100
+
+    def test_metadata_reports_applied_offset(self, wheel):
+        wheel.set_filter("R")
+
+        keywords = dict((key, value) for key, value, _ in wheel.get_metadata(None))
+
+        assert keywords["FOCUSOFF"] == 25
+
+
+#
+# focus offset failures
+#
+class TestFilterWheelFocusOffsetErrors:
+    @pytest.fixture
+    def unreachable(self, monkeypatch):
+        def factory(**config):
+            wheel = FakeFilterWheel()
+            wheel["filters"] = FILTERS
+            wheel["focuser"] = FOCUSER_LOCATION
+            wheel["focus_offsets"] = FOCUS_OFFSETS
+            for key, value in config.items():
+                wheel[key] = value
+
+            def no_such_object(url):
+                raise ObjectNotFoundException(f"{url} not found.")
+
+            monkeypatch.setattr(wheel, "get_proxy", no_such_object)
+            wheel.__start__()
+            return wheel
+
+        return factory
+
+    def test_unreachable_focuser_fails_the_filter_change(self, unreachable, events):
+        wheel = unreachable()
+
+        with pytest.raises(FocusOffsetException):
+            wheel.set_filter("V")
+
+        # the wheel itself did move and said so: the caller decides what to do
+        assert wheel.get_filter() == "V"
+        assert events == [("V", "U")]
+
+    def test_focus_offset_not_required_only_logs(
+        self, unreachable, events, chimera_log
+    ):
+        wheel = unreachable(focus_offset_required=False)
+
+        assert wheel.set_filter("V")
+        assert wheel.get_filter() == "V"
+        assert events == [("V", "U")]
+        assert any(
+            "Could not apply 100 step focus offset" in message
+            for message in chimera_log
+        )
+
+    def test_malformed_offsets_fail_at_startup(self, make_wheel, focuser):
+        with pytest.raises(FocusOffsetException):
+            make_wheel(
+                focuser_proxy=focuser,
+                focuser=FOCUSER_LOCATION,
+                focus_offsets="U:deadbeef",
+            )
+
+    def test_offsets_for_unknown_filter_fail_at_startup(self, make_wheel, focuser):
+        with pytest.raises(FocusOffsetException):
+            make_wheel(
+                focuser_proxy=focuser,
+                focuser=FOCUSER_LOCATION,
+                focus_offsets="Z:100",
+            )
+
+
+#
+# legacy drivers
+#
+def test_driver_overriding_set_filter_is_warned(chimera_log):
+    class LegacyFilterWheel(FakeFilterWheel):
+        def set_filter(self, filter):
+            pass
+
+    # warned at construction: a legacy driver that also overrides __start__
+    # without chaining up would never reach a check placed there
+    LegacyFilterWheel()
+
+    assert any("overrides set_filter()" in message for message in chimera_log)

--- a/tests/chimera/instruments/test_filterwheel.py
+++ b/tests/chimera/instruments/test_filterwheel.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from chimera.core.exceptions import ChimeraException, ObjectNotFoundException
+from chimera.core.exceptions import ObjectNotFoundException
 from chimera.instruments.fakefilterwheel import FakeFilterWheel
 from chimera.interfaces.filterwheel import (
     FocusOffsetException,
@@ -223,19 +223,6 @@ class TestFilterWheelFocusOffsets:
 
         wheel.set_filter("U")
         assert focuser.position == start
-
-    def test_unknown_previous_filter(self, wheel, focuser, monkeypatch):
-        # a wheel that has not homed since power-up cannot report its current
-        # filter (chimera-fli raises here); the offset is applied from zero
-        def position_unknown():
-            raise ChimeraException("wheel has not homed yet")
-
-        monkeypatch.setattr(wheel, "get_filter", position_unknown)
-        start = focuser.position
-
-        wheel.set_filter("U")
-
-        assert focuser.position == start - 100
 
     def test_metadata_reports_applied_offset(self, wheel):
         wheel.set_filter("R")

--- a/tests/chimera/instruments/test_filterwheel.py
+++ b/tests/chimera/instruments/test_filterwheel.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
 
-import logging
 import time
 
 import pytest
@@ -24,7 +23,9 @@ def filter_change_clbk(new_filter, old_filter):
 @pytest.fixture
 def filterwheel(manager):
     manager.add_class(
-        FakeFilterWheel, "fake", {"device": "/dev/ttyS0", "filters": "U B V R I"}
+        FakeFilterWheel,
+        "fake",
+        {"device": "/dev/ttyS0", "filters": ["U", "B", "V", "R", "I"]},
     )
     fired_events.clear()
 
@@ -60,9 +61,9 @@ class TestFakeFilterWheel:
 # applies the configured offset through the focuser role.
 # ---------------------------------------------------------------------------
 
-FILTERS = "U B V R I"
+FILTERS = ["U", "B", "V", "R", "I"]
 # I is deliberately left out: filters with no entry get no offset
-FOCUS_OFFSETS = "U:-100 B:0 V:0 R:25"
+FOCUS_OFFSETS = {"U": -100, "B": 0, "V": 0, "R": 25}
 
 FOCUSER_LOCATION = "/FakeFocuser/0"
 
@@ -102,24 +103,6 @@ def focuser():
 
 
 @pytest.fixture
-def chimera_log():
-    """chimera's logger does not propagate to the root one, so caplog is blind."""
-    messages = []
-
-    class Recorder(logging.Handler):
-        def emit(self, record):
-            messages.append(record.getMessage())
-
-    handler = Recorder()
-    logger = logging.getLogger("chimera")
-    logger.addHandler(handler)
-    try:
-        yield messages
-    finally:
-        logger.removeHandler(handler)
-
-
-@pytest.fixture
 def make_wheel(monkeypatch, events):
     def factory(focuser_proxy=None, **config):
         wheel = FakeFilterWheel()
@@ -150,7 +133,7 @@ def wheel(make_wheel, focuser):
 #
 class TestFilterWheel:
     def test_get_filters(self, make_wheel):
-        assert make_wheel().get_filters() == FILTERS.split()
+        assert make_wheel().get_filters() == FILTERS
 
     def test_set_filter_moves_and_fires_event(self, make_wheel, events):
         wheel = make_wheel()
@@ -168,7 +151,7 @@ class TestFilterWheel:
             make_wheel().set_filter("Z")
 
     def test_no_focus_offsets_by_default(self, make_wheel):
-        assert make_wheel().get_focus_offsets() == {}
+        assert make_wheel()._focus_offsets == {}
 
     def test_offsets_without_a_focuser_are_ignored(self, make_wheel, focuser):
         # no `focuser` configured, so nothing to compensate with
@@ -199,7 +182,7 @@ class TestFilterWheelFocusOffsets:
     """
 
     def test_get_focus_offsets(self, wheel):
-        assert wheel.get_focus_offsets() == {"U": -100, "B": 0, "V": 0, "R": 25}
+        assert wheel._focus_offsets == {"U": -100, "B": 0, "V": 0, "R": 25}
 
     def test_offset_applied_on_filter_change(self, wheel, focuser):
         # the wheel starts on U, so the focuser is assumed to already carry
@@ -295,24 +278,12 @@ class TestFilterWheelFocusOffsetErrors:
         assert wheel.get_filter() == "V"
         assert events == [("V", "U")]
 
-    def test_focus_offset_not_required_only_logs(
-        self, unreachable, events, chimera_log
-    ):
-        wheel = unreachable(focus_offset_required=False)
-
-        assert wheel.set_filter("V")
-        assert wheel.get_filter() == "V"
-        assert events == [("V", "U")]
-        assert any(
-            "Could not apply a 100 focus offset" in message for message in chimera_log
-        )
-
     def test_malformed_offsets_fail_at_startup(self, make_wheel, focuser):
         with pytest.raises(FocusOffsetException):
             make_wheel(
                 focuser_proxy=focuser,
                 focuser=FOCUSER_LOCATION,
-                focus_offsets="U:deadbeef",
+                focus_offsets={"U": "deadbeef"},
             )
 
     def test_offsets_for_unknown_filter_fail_at_startup(self, make_wheel, focuser):
@@ -320,20 +291,5 @@ class TestFilterWheelFocusOffsetErrors:
             make_wheel(
                 focuser_proxy=focuser,
                 focuser=FOCUSER_LOCATION,
-                focus_offsets="Z:100",
+                focus_offsets={"Z": 100},
             )
-
-
-#
-# legacy drivers
-#
-def test_driver_overriding_set_filter_is_warned(chimera_log):
-    class LegacyFilterWheel(FakeFilterWheel):
-        def set_filter(self, filter):
-            pass
-
-    # warned at construction: a legacy driver that also overrides __start__
-    # without chaining up would never reach a check placed there
-    LegacyFilterWheel()
-
-    assert any("overrides set_filter()" in message for message in chimera_log)


### PR DESCRIPTION
Folds the [chimera-filterfocus](https://github.com/astroufsc/chimera-filterfocus) plugin into the filter wheel itself, the way `TelescopeBase.slew_to_object()`/`move_offset()` and `CameraBase.expose()` already compose high-level behaviour on top of a driver primitive.

## What changes

`FilterWheelBase.set_filter()` becomes concrete and final: it validates the filter name, captures the outgoing filter, calls the driver's new `_set_filter()` primitive, applies the focus offset, then fires `filter_change`. Drivers only move the wheel now — the validation and the event fire that each of them copy-pasted (with subtly different behaviour) are gone.

```yaml
filterwheel:
  name: fake
  type: FakeFilterWheel
  filters: "U B V R I"
  focuser: /FakeFocuser/fake
  focus_offsets: "U:-100 B:0 V:0 R:25"
```

Leaving `focuser` unset disables the whole thing, which is the default.

## Why not leave it in the plugin

- **The offset was applied asynchronously.** The plugin subscribed to `filter_change` and moved the focuser from the callback, so `set_filter()` returned before the focuser had moved. `ExposeHandler` goes straight from `filterwheel.set_filter()` to `camera.expose()` (`handlers.py:166`), so an exposure could start while the focuser was still travelling. Doing it inside `set_filter()` closes that window.
- **It failed silently.** `offsets[new_filter] - offsets[old_filter]` is a bare dict index, raising `KeyError` inside an event callback — where nobody sees it — for any filter missing from `focus_filters`, or when `old_filter` is `None` (which chimera-fli legitimately reports for a wheel that has not homed since power-up).
- **The config duplicated `filters`** in a second parallel list that misaligned silently.

## Semantics

- Moves are **relative**: only `offset[new] - applied` is moved, never an absolute `move_to()`, so autofocus results and temperature compensation are not clobbered.
- The wheel tracks **the offset it believes is on the focuser**, not the previous filter, so an unknown/unhomed previous filter no longer breaks the arithmetic.
- **Filters absent from the table get no offset** — an observatory can add a filter before it has a measured offset.
- Offsets are rounded to whole focuser steps at parse time, so repeated filter cycling does not accumulate drift.
- On failure the wheel has already moved and `filter_change` has already fired; `set_filter()` then raises `FocusOffsetException`. Set `focus_offset_required: false` to only log the error and carry on.
- `FOCUSOFF` is added to the wheel's FITS metadata once an offset has been applied, and `get_metadata()` now honours `get_metadata_override()` like the telescope and camera do.

## Compatibility

Out-of-tree drivers that still implement `set_filter()` keep working — they just get no focus compensation, and they are warned about it at construction:

> `T80SFilterWheel overrides set_filter(): focus offsets will NOT be applied. Rename it to _set_filter() and drop the filter validation and the filter_change() call, which FilterWheelBase now does.`

`FakeFilterWheel` is migrated here. chimera-fli, chimera-ascom and chimera-sbig get one-line PRs of their own.

Users of the plugin drop the `FilterFocus` controller block and move `focus_filters`/`focus_difference` onto the wheel as `focus_offsets`; documented in `docs/configuring.rst`.

## Testing

`tests/chimera/instruments/test_filterwheel.py` is rewritten — it imported a `base` module that does not exist, so it had been failing collection. 18 tests now cover the wheel contract, the offset arithmetic (including round-trip with no drift), unhomed wheels, missing entries, malformed tables, both failure policies, and the legacy-driver warning.

Verified end to end against a live `chimera` with `FakeFilterWheel` + `FakeFocuser`:

```
$ chimera-filter --info
Filter Wheel: tcp://127.0.0.1:7699/FakeFilterWheel/fake (/dev/ttyS0)
Current Filter: U
Available filters: U B V R I
Focus offsets (/FakeFocuser/fake): U:-100 B:+0 V:+0 R:+25 I:+0

U -> V  focuser 3500 -> 3600   (backs out U's -100)
V -> R  focuser 3600 -> 3625
R -> I  focuser 3625 -> 3600   (I has no offset)
I -> U  focuser 3600 -> 3500   (back to start)
```

The 2 test failures and 17 collection errors remaining in `tests/chimera/{instruments,util,controllers}` are all present on `master` before this branch.

Noticed while writing this: #258.