### PR TITLE
Contain dome failures to a log line instead of killing the program

### DIFF
--- a/src/chimera/controllers/imageserver/imagerequest.py
+++ b/src/chimera/controllers/imageserver/imagerequest.py
@@ -115,8 +115,15 @@ class ImageRequest(dict):
             if not dome.ping():
                 log.info("No dome present, taking exposure without dome sync.")
                 return
-            dome.sync_with_tel()
-            if dome.is_sync_with_tel():
+            # a dome hiccup must not abort the exposure (and with it the
+            # focus run or the whole program): degrade to the log line below
+            try:
+                dome.sync_with_tel()
+                synced = dome.is_sync_with_tel()
+            except Exception as e:
+                log.warning(f"Dome sync failed ({e}). Taking exposure anyway.")
+                return
+            if synced:
                 log.debug("Dome slit position synchronized with telescope position.")
             else:
                 log.info(

--- a/src/chimera/instruments/dome.py
+++ b/src/chimera/instruments/dome.py
@@ -123,6 +123,10 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeSync):
             try:
                 self.log.debug(f"[queue] slewing to {target}")
                 self.slew_to_az(target)
+            except Exception as e:
+                # control() must survive a failed slew: a raise here would
+                # kill the control loop and silently stop dome tracking
+                self.log.warning(f"[queue] slew to {target} failed ({e})")
             finally:
                 self.log.debug(f"[queue] slew to {target} complete")
                 self.queue.task_done()


### PR DESCRIPTION
Two small blast-radius fixes motivated by a live failure (2026-07-22): a dome serial hiccup while gathering FITS headers propagated out of `ImageRequest.begin_exposure()` and aborted the exposure, the autofocus run and the whole scheduled program.

- **imagerequest**: `dome.sync_with_tel()` / `is_sync_with_tel()` are now wrapped in try/except. The "could not be synchronized" case has always been a log-only branch; a *raising* sync now degrades the same way (warning + exposure proceeds) instead of killing the camera path.
- **dome (base)**: `_process_queue()` catches exceptions from `slew_to_az()`. It is called from `control()`, and `__main__` has no exception handling around the control loop — so one failed slew killed the loop thread and the dome silently stopped tracking for the rest of the night. Now it logs a warning and retries naturally on the next cycle via `_need_to_move()`.

Companion driver-side work (single-owner serial I/O thread for the LNA dome) is in astroufsc/chimera-lna; this core change is deliberately independent of it.