### PR TITLE
Add the DomeWindScreen interface

### DIFF
--- a/src/chimera/cli/dome.py
+++ b/src/chimera/cli/dome.py
@@ -118,19 +118,21 @@ class ChimeraDome(ChimeraCLI):
         self.out("OK")
 
     @action(
-        long="move-screen",
+        long="move-wind-screen",
         type="float",
         metavar="ALT",
         help="Move dome wind screen to ALT degrees",
         help_group="SHUTTER",
-        action_group="SCREEN",
+        action_group="WIND_SCREEN",
     )
-    def move_screen(self, options):
+    def move_wind_screen(self, options):
         if not self.dome.features("DomeWindScreen"):
             self.exit("Dome does not have a wind screen.")
 
-        self.out("Moving dome wind screen to %.2f ... " % options.move_screen, end="")
-        self.dome.move_screen(options.move_screen)
+        self.out(
+            "Moving dome wind screen to %.2f ... " % options.move_wind_screen, end=""
+        )
+        self.dome.move_wind_screen(options.move_wind_screen)
         self.out("OK")
 
     @action(
@@ -313,7 +315,9 @@ class ChimeraDome(ChimeraCLI):
                 self.out("Dome flap is closed.")
 
         if self.dome.features("DomeWindScreen"):
-            self.out("Current wind screen altitude: %s." % self.dome.get_screen())
+            self.out(
+                "Current wind screen altitude: %s." % self.dome.get_wind_screen_alt()
+            )
 
         if self.dome["lamps"] is not None:
             for lamp in self.dome["lamps"]:
@@ -362,7 +366,7 @@ class ChimeraDome(ChimeraCLI):
         if hasattr(self, "dome"):
             self.dome.abort_slew()
             if self.dome.features("DomeWindScreen"):
-                self.dome.abort_screen()
+                self.dome.abort_wind_screen_move()
 
 
 def main():

--- a/src/chimera/cli/dome.py
+++ b/src/chimera/cli/dome.py
@@ -113,6 +113,22 @@ class ChimeraDome(ChimeraCLI):
         self.out("OK")
 
     @action(
+        long="move-screen",
+        type="float",
+        metavar="ALT",
+        help="Move dome wind screen to ALT degrees",
+        help_group="SHUTTER",
+        action_group="SCREEN",
+    )
+    def move_screen(self, options):
+        if not self.dome.features("DomeWindScreen"):
+            self.exit("Dome does not have a wind screen.")
+
+        self.out("Moving dome wind screen to %.2f ... " % options.move_screen, end="")
+        self.dome.move_screen(options.move_screen)
+        self.out("OK")
+
+    @action(
         long="light-off",
         help="Turn light off",
         help_group="LIGHT",
@@ -285,6 +301,9 @@ class ChimeraDome(ChimeraCLI):
         else:
             self.out("Dome slit is closed.")
 
+        if self.dome.features("DomeWindScreen"):
+            self.out("Current wind screen altitude: %s." % self.dome.get_screen())
+
         if self.dome["lamps"] is not None:
             for lamp in self.dome["lamps"]:
                 onoff = green("ON") if self.lamp().is_switched_on() else red("OFF")
@@ -333,6 +352,8 @@ class ChimeraDome(ChimeraCLI):
         if hasattr(self, "dome"):
             dome = copy.copy(self.dome)
             dome.abort_slew()
+            if dome.features("DomeWindScreen"):
+                dome.abort_screen()
 
 
 def main():

--- a/src/chimera/cli/dome.py
+++ b/src/chimera/cli/dome.py
@@ -96,6 +96,9 @@ class ChimeraDome(ChimeraCLI):
         action_group="FLAP",
     )
     def open_flap(self, options):
+        if not self.dome.features("DomeFlap"):
+            self.exit("Dome does not have a flap.")
+
         self.out("Opening dome flap ... ", end="")
         self.dome.open_flap()
         self.out("OK")
@@ -107,6 +110,9 @@ class ChimeraDome(ChimeraCLI):
         action_group="FLAP",
     )
     def close_flap(self, options):
+        if not self.dome.features("DomeFlap"):
+            self.exit("Dome does not have a flap.")
+
         self.out("Closing dome flap ... ", end="")
         self.dome.close_flap()
         self.out("OK")
@@ -299,6 +305,12 @@ class ChimeraDome(ChimeraCLI):
             self.out("Dome slit is open.")
         else:
             self.out("Dome slit is closed.")
+
+        if self.dome.features("DomeFlap"):
+            if self.dome.is_flap_open():
+                self.out("Dome flap is open.")
+            else:
+                self.out("Dome flap is closed.")
 
         if self.dome.features("DomeWindScreen"):
             self.out("Current wind screen altitude: %s." % self.dome.get_screen())

--- a/src/chimera/instruments/dome.py
+++ b/src/chimera/instruments/dome.py
@@ -249,6 +249,14 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeSync):
             ("DOME_SLT", str(slit), "Dome slit status"),
         ]
 
+        # every dome inherits DomeFlap, so features() cannot tell us whether the
+        # driver actually implements it
+        try:
+            flap = "Open" if self.is_flap_open() else "Closed"
+            metadata.append(("DOME_FLP", flap, "Dome flap status"))
+        except NotImplementedError:
+            pass
+
         if self.features("DomeWindScreen"):
             metadata.append(
                 ("DOME_WSC", f"{self.get_screen():.2f}", "Dome wind screen altitude")

--- a/src/chimera/instruments/dome.py
+++ b/src/chimera/instruments/dome.py
@@ -54,6 +54,13 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeSync):
             except Exception as e:
                 self.log.warning("Unable to park dome: %s", str(e))
 
+        if self["park_on_shutdown"] and self.features("DomeWindScreen"):
+            try:
+                self.log.info("Parking the wind screen...")
+                self.move_screen(self["screen_park_position"])
+            except Exception as e:
+                self.log.warning("Unable to park the wind screen: %s", str(e))
+
         if self["close_on_shutdown"] and self.is_slit_open():
             try:
                 self.log.info("Closing the slit...")
@@ -75,6 +82,10 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeSync):
             return True
 
         self._move_if_needed(self._get_telescope_az())
+
+        # _get_telescope_az() drops to Stand when the telescope is unreachable
+        if self.get_mode() == Mode.Track:
+            self._move_screen_if_needed(self.telescope.get_alt())
 
         # flag all waiting threads that the control loop already checked the new telescope position
         # probably adding new azimuth to the queue
@@ -111,6 +122,30 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeSync):
 
     def _need_to_move(self, az: float) -> bool:
         return abs(az - self.get_az()) >= self["az_resolution"]
+
+    def _move_screen_if_needed(self, telescope_alt: float) -> None:
+        if not (self.features("DomeWindScreen") and self["screen_track"]):
+            return
+
+        target = self._screen_target(telescope_alt)
+        current = self.get_screen()
+
+        if abs(target - current) < self["screen_alt_resolution"]:
+            self.log.debug(
+                f"[control] no need to move the wind screen"
+                f" (screen alt={current}, target={target}.)"
+            )
+            return
+
+        self.log.debug(f"[control] moving the wind screen to {target}")
+        self.move_screen(target)
+
+    def _screen_target(self, telescope_alt: float) -> float:
+        # clamp so tracking never asks for a position outside the screen travel
+        return min(
+            max(telescope_alt + self["screen_offset"], self["screen_min_alt"]),
+            self["screen_max_alt"],
+        )
 
     def _process_queue(self):
         if self.queue.empty():
@@ -207,9 +242,16 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeSync):
         else:
             slit = "Closed"
 
-        return [
+        metadata = [
             ("DOME_MDL", str(self["model"]), "Dome Model"),
             ("DOME_TYP", str(self["style"]), "Dome Type"),
             ("DOME_TRK", str(self["mode"]), "Dome Tracking/Standing"),
             ("DOME_SLT", str(slit), "Dome slit status"),
         ]
+
+        if self.features("DomeWindScreen"):
+            metadata.append(
+                ("DOME_WSC", f"{self.get_screen():.2f}", "Dome wind screen altitude")
+            )
+
+        return metadata

--- a/src/chimera/instruments/dome.py
+++ b/src/chimera/instruments/dome.py
@@ -9,13 +9,13 @@ from typing import cast
 
 from chimera.core.chimeraobject import ChimeraObject
 from chimera.core.lock import lock
-from chimera.interfaces.dome import DomeFlap, DomeSlew, DomeSlit, DomeSync, Mode
+from chimera.interfaces.dome import DomeSlew, DomeSlit, DomeSync, Mode
 from chimera.interfaces.telescope import Telescope
 
 __all__ = ["DomeBase"]
 
 
-class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeSync):
+class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeSync):
     def __init__(self):
         ChimeraObject.__init__(self)
 
@@ -220,17 +220,6 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeSync):
     def is_slit_open(self) -> bool:
         raise NotImplementedError()
 
-    @lock
-    def open_flap(self) -> None:
-        raise NotImplementedError()
-
-    @lock
-    def close_flap(self) -> None:
-        raise NotImplementedError()
-
-    def is_flap_open(self) -> bool:
-        raise NotImplementedError()
-
     def get_metadata(self, request) -> list[tuple[str, str, str]]:
         # Check first if there is metadata from a metadata override method.
         metadata = self.get_metadata_override(request)
@@ -249,13 +238,9 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeFlap, DomeSync):
             ("DOME_SLT", str(slit), "Dome slit status"),
         ]
 
-        # every dome inherits DomeFlap, so features() cannot tell us whether the
-        # driver actually implements it
-        try:
+        if self.features("DomeFlap"):
             flap = "Open" if self.is_flap_open() else "Closed"
             metadata.append(("DOME_FLP", flap, "Dome flap status"))
-        except NotImplementedError:
-            pass
 
         if self.features("DomeWindScreen"):
             metadata.append(

--- a/src/chimera/instruments/dome.py
+++ b/src/chimera/instruments/dome.py
@@ -57,7 +57,7 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeSync):
         if self["park_on_shutdown"] and self.features("DomeWindScreen"):
             try:
                 self.log.info("Parking the wind screen...")
-                self.move_screen(self["screen_park_position"])
+                self.move_wind_screen(self["wind_screen_park_position"])
             except Exception as e:
                 self.log.warning("Unable to park the wind screen: %s", str(e))
 
@@ -85,7 +85,7 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeSync):
 
         # _get_telescope_az() drops to Stand when the telescope is unreachable
         if self.get_mode() == Mode.Track:
-            self._move_screen_if_needed(self.telescope.get_alt())
+            self._move_wind_screen_if_needed(self.telescope.get_alt())
 
         # flag all waiting threads that the control loop already checked the new telescope position
         # probably adding new azimuth to the queue
@@ -123,28 +123,30 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeSync):
     def _need_to_move(self, az: float) -> bool:
         return abs(az - self.get_az()) >= self["az_resolution"]
 
-    def _move_screen_if_needed(self, telescope_alt: float) -> None:
-        if not (self.features("DomeWindScreen") and self["screen_track"]):
+    def _move_wind_screen_if_needed(self, telescope_alt: float) -> None:
+        if not (self.features("DomeWindScreen") and self["wind_screen_track"]):
             return
 
-        target = self._screen_target(telescope_alt)
-        current = self.get_screen()
+        target = self._wind_screen_target(telescope_alt)
+        current = self.get_wind_screen_alt()
 
-        if abs(target - current) < self["screen_alt_resolution"]:
+        if abs(target - current) < self["wind_screen_alt_resolution"]:
             self.log.debug(
                 f"[control] no need to move the wind screen"
-                f" (screen alt={current}, target={target}.)"
+                f" (wind screen alt={current}, target={target}.)"
             )
             return
 
         self.log.debug(f"[control] moving the wind screen to {target}")
-        self.move_screen(target)
+        self.move_wind_screen(target)
 
-    def _screen_target(self, telescope_alt: float) -> float:
-        # clamp so tracking never asks for a position outside the screen travel
+    def _wind_screen_target(self, telescope_alt: float) -> float:
+        # clamp so tracking never asks for a position outside the wind screen travel
         return min(
-            max(telescope_alt + self["screen_offset"], self["screen_min_alt"]),
-            self["screen_max_alt"],
+            max(
+                telescope_alt + self["wind_screen_offset"], self["wind_screen_min_alt"]
+            ),
+            self["wind_screen_max_alt"],
         )
 
     def _process_queue(self):
@@ -244,7 +246,11 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeSync):
 
         if self.features("DomeWindScreen"):
             metadata.append(
-                ("DOME_WSC", f"{self.get_screen():.2f}", "Dome wind screen altitude")
+                (
+                    "DOME_WSC",
+                    f"{self.get_wind_screen_alt():.2f}",
+                    "Dome wind screen altitude",
+                )
             )
 
         return metadata

--- a/src/chimera/instruments/fakedome.py
+++ b/src/chimera/instruments/fakedome.py
@@ -7,13 +7,14 @@ import time
 from chimera.core.lock import lock
 from chimera.instruments.dome import DomeBase
 from chimera.interfaces.dome import (
+    DomeFlap,
     DomeStatus,
     DomeWindScreen,
     InvalidDomePositionException,
 )
 
 
-class FakeDome(DomeBase, DomeWindScreen):
+class FakeDome(DomeBase, DomeFlap, DomeWindScreen):
     def __init__(self):
         DomeBase.__init__(self)
 

--- a/src/chimera/instruments/fakedome.py
+++ b/src/chimera/instruments/fakedome.py
@@ -25,10 +25,10 @@ class FakeDome(DomeBase, DomeFlap, DomeWindScreen):
         self._abort = threading.Event()
         self._max_slew_time = 5 / 180.0
 
-        self._screen_alt: float = 0.0
-        self._screen_moving = False
-        self._abort_screen = threading.Event()
-        self._max_screen_move_time = 5 / 90.0
+        self._wind_screen_alt: float = 0.0
+        self._wind_screen_moving = False
+        self._abort_wind_screen_move = threading.Event()
+        self._max_wind_screen_move_time = 5 / 90.0
 
     def __start__(self):
         self.set_hz(1.0 / 30.0)
@@ -135,22 +135,22 @@ class FakeDome(DomeBase, DomeFlap, DomeWindScreen):
         return self._flap_open
 
     @lock
-    def move_screen(self, alt: float) -> None:
-        if not self["screen_min_alt"] <= alt <= self["screen_max_alt"]:
+    def move_wind_screen(self, alt: float) -> None:
+        if not self["wind_screen_min_alt"] <= alt <= self["wind_screen_max_alt"]:
             raise InvalidDomePositionException(
                 f"Cannot move the wind screen to {alt}. Outside screen limits."
             )
 
-        self._abort_screen.clear()
-        self._screen_moving = True
+        self._abort_wind_screen_move.clear()
+        self._wind_screen_moving = True
 
-        self.screen_begin(self.get_screen())
+        self.wind_screen_move_begin(self.get_wind_screen_alt())
         self.log.info(f"Moving the wind screen to {alt}")
 
         # move time ~ distance from current position
-        distance = abs(alt - self._screen_alt)
-        direction = 1 if alt >= self._screen_alt else -1
-        move_time = distance * self._max_screen_move_time
+        distance = abs(alt - self._wind_screen_alt)
+        direction = 1 if alt >= self._wind_screen_alt else -1
+        move_time = distance * self._max_wind_screen_move_time
 
         self.log.info(f"Wind screen move time ~ {move_time:.3f} s")
 
@@ -158,7 +158,7 @@ class FakeDome(DomeBase, DomeFlap, DomeWindScreen):
 
         t = 0
         while t < move_time:
-            if self._abort_screen.is_set():
+            if self._abort_wind_screen_move.is_set():
                 status = DomeStatus.ABORTED
                 break
 
@@ -166,25 +166,25 @@ class FakeDome(DomeBase, DomeFlap, DomeWindScreen):
             t += 0.1
 
         if status == DomeStatus.OK:
-            self._screen_alt = alt
+            self._wind_screen_alt = alt
         else:
             # assume half movement in case of abort
-            self._screen_alt += direction * distance / 2.0
+            self._wind_screen_alt += direction * distance / 2.0
 
-        self._screen_moving = False
-        self.screen_complete(self.get_screen(), status)
+        self._wind_screen_moving = False
+        self.wind_screen_move_complete(self.get_wind_screen_alt(), status)
 
     @lock
-    def get_screen(self) -> float:
-        return self._screen_alt
+    def get_wind_screen_alt(self) -> float:
+        return self._wind_screen_alt
 
-    def is_screen_moving(self) -> bool:
-        return self._screen_moving
+    def is_wind_screen_moving(self) -> bool:
+        return self._wind_screen_moving
 
-    def abort_screen(self) -> None:
-        if not self.is_screen_moving():
+    def abort_wind_screen_move(self) -> None:
+        if not self.is_wind_screen_moving():
             return
 
-        self._abort_screen.set()
-        while self.is_screen_moving():
+        self._abort_wind_screen_move.set()
+        while self.is_wind_screen_moving():
             time.sleep(0.1)

--- a/src/chimera/instruments/fakedome.py
+++ b/src/chimera/instruments/fakedome.py
@@ -6,10 +6,14 @@ import time
 
 from chimera.core.lock import lock
 from chimera.instruments.dome import DomeBase
-from chimera.interfaces.dome import DomeStatus, InvalidDomePositionException
+from chimera.interfaces.dome import (
+    DomeStatus,
+    DomeWindScreen,
+    InvalidDomePositionException,
+)
 
 
-class FakeDome(DomeBase):
+class FakeDome(DomeBase, DomeWindScreen):
     def __init__(self):
         DomeBase.__init__(self)
 
@@ -19,6 +23,11 @@ class FakeDome(DomeBase):
         self._flap_open = False
         self._abort = threading.Event()
         self._max_slew_time = 5 / 180.0
+
+        self._screen_alt: float = 0.0
+        self._screen_moving = False
+        self._abort_screen = threading.Event()
+        self._max_screen_move_time = 5 / 90.0
 
     def __start__(self):
         self.set_hz(1.0 / 30.0)
@@ -123,3 +132,58 @@ class FakeDome(DomeBase):
 
     def is_flap_open(self):
         return self._flap_open
+
+    @lock
+    def move_screen(self, alt: float) -> None:
+        if not self["screen_min_alt"] <= alt <= self["screen_max_alt"]:
+            raise InvalidDomePositionException(
+                f"Cannot move the wind screen to {alt}. Outside screen limits."
+            )
+
+        self._abort_screen.clear()
+        self._screen_moving = True
+
+        self.screen_begin(self.get_screen())
+        self.log.info(f"Moving the wind screen to {alt}")
+
+        # move time ~ distance from current position
+        distance = abs(alt - self._screen_alt)
+        direction = 1 if alt >= self._screen_alt else -1
+        move_time = distance * self._max_screen_move_time
+
+        self.log.info(f"Wind screen move time ~ {move_time:.3f} s")
+
+        status = DomeStatus.OK
+
+        t = 0
+        while t < move_time:
+            if self._abort_screen.is_set():
+                status = DomeStatus.ABORTED
+                break
+
+            time.sleep(0.1)
+            t += 0.1
+
+        if status == DomeStatus.OK:
+            self._screen_alt = alt
+        else:
+            # assume half movement in case of abort
+            self._screen_alt += direction * distance / 2.0
+
+        self._screen_moving = False
+        self.screen_complete(self.get_screen(), status)
+
+    @lock
+    def get_screen(self) -> float:
+        return self._screen_alt
+
+    def is_screen_moving(self) -> bool:
+        return self._screen_moving
+
+    def abort_screen(self) -> None:
+        if not self.is_screen_moving():
+            return
+
+        self._abort_screen.set()
+        while self.is_screen_moving():
+            time.sleep(0.1)

--- a/src/chimera/interfaces/dome.py
+++ b/src/chimera/interfaces/dome.py
@@ -63,6 +63,16 @@ class DomeConfig:
     init_timeout: int = 5
     open_timeout: int = 20
     close_timeout: int = 20
+    # wind screen (DomeWindScreen domes only), all altitudes in degrees
+    screen_timeout: int = 60
+    # follow the telescope altitude when the dome is in Track mode
+    screen_track: bool = True
+    screen_offset: float = 0.0
+    screen_min_alt: float = 0.0
+    screen_max_alt: float = 90.0
+    screen_park_position: float = 0.0
+    # screen position resolution in degrees
+    screen_alt_resolution: float = 2
     # list of fans of the dome, i.e.: fans: ['/FakeFan/fake1', '/FakeFan/fake2']
     fans: list[str] = field(default_factory=list[str])
     # list of lamps of the dome, i.e.: lamps: ['/FakeLamp/fake1']
@@ -89,6 +99,14 @@ class Dome(Interface):
         "init_timeout": 5,
         "open_timeout": 20,
         "close_timeout": 20,
+        # wind screen (DomeWindScreen domes only), all altitudes in degrees
+        "screen_timeout": 60,
+        "screen_track": True,  # follow the telescope alt when in Track mode
+        "screen_offset": 0.0,
+        "screen_min_alt": 0.0,
+        "screen_max_alt": 90.0,
+        "screen_park_position": 0.0,
+        "screen_alt_resolution": 2,  # screen position resolution in degrees
         "fans": [],  # list of fans of the dome, i.e.: fans: ['/FakeFan/fake1', '/FakeFan/fake2']
         "lamps": [],  # list of lamps of the dome, i.e.: lamps: ['/FakeLamp/fake1']
     }
@@ -284,6 +302,10 @@ class DomeWindScreen(Dome):
 
     Altitudes are in decimal degrees, horizon = 0 and zenith = 90, the same
     convention used by ASCOM's Dome.Altitude.
+
+    When the dome is in L{Mode.Track} and the 'screen_track' config option is
+    set, the screen follows the telescope altitude plus 'screen_offset',
+    clamped to ['screen_min_alt', 'screen_max_alt'].
     """
 
     def move_screen(self, alt: float) -> None:
@@ -310,6 +332,22 @@ class DomeWindScreen(Dome):
         @rtype: float
         """
         ...
+
+    def is_screen_moving(self) -> bool:
+        """
+        Ask if the wind screen is moving right now.
+
+        @return: True if the screen is moving, False otherwise.
+        @rtype: bool
+        """
+        ...
+
+    def abort_screen(self) -> None:
+        """
+        Try to abort the current screen movement.
+
+        @rtype: None
+        """
 
     @event
     def screen_begin(self, alt: float) -> None:

--- a/src/chimera/interfaces/dome.py
+++ b/src/chimera/interfaces/dome.py
@@ -64,15 +64,15 @@ class DomeConfig:
     open_timeout: int = 20
     close_timeout: int = 20
     # wind screen (DomeWindScreen domes only), all altitudes in degrees
-    screen_timeout: int = 60
+    wind_screen_timeout: int = 60
     # follow the telescope altitude when the dome is in Track mode
-    screen_track: bool = True
-    screen_offset: float = 0.0
-    screen_min_alt: float = 0.0
-    screen_max_alt: float = 90.0
-    screen_park_position: float = 0.0
-    # screen position resolution in degrees
-    screen_alt_resolution: float = 2
+    wind_screen_track: bool = True
+    wind_screen_offset: float = 0.0
+    wind_screen_min_alt: float = 0.0
+    wind_screen_max_alt: float = 90.0
+    wind_screen_park_position: float = 0.0
+    # wind screen position resolution in degrees
+    wind_screen_alt_resolution: float = 2
     # list of fans of the dome, i.e.: fans: ['/FakeFan/fake1', '/FakeFan/fake2']
     fans: list[str] = field(default_factory=list[str])
     # list of lamps of the dome, i.e.: lamps: ['/FakeLamp/fake1']
@@ -100,13 +100,13 @@ class Dome(Interface):
         "open_timeout": 20,
         "close_timeout": 20,
         # wind screen (DomeWindScreen domes only), all altitudes in degrees
-        "screen_timeout": 60,
-        "screen_track": True,  # follow the telescope alt when in Track mode
-        "screen_offset": 0.0,
-        "screen_min_alt": 0.0,
-        "screen_max_alt": 90.0,
-        "screen_park_position": 0.0,
-        "screen_alt_resolution": 2,  # screen position resolution in degrees
+        "wind_screen_timeout": 60,
+        "wind_screen_track": True,  # follow the telescope alt when in Track mode
+        "wind_screen_offset": 0.0,
+        "wind_screen_min_alt": 0.0,
+        "wind_screen_max_alt": 90.0,
+        "wind_screen_park_position": 0.0,
+        "wind_screen_alt_resolution": 2,  # wind screen position resolution in degrees
         "fans": [],  # list of fans of the dome, i.e.: fans: ['/FakeFan/fake1', '/FakeFan/fake2']
         "lamps": [],  # list of lamps of the dome, i.e.: lamps: ['/FakeLamp/fake1']
     }
@@ -302,73 +302,73 @@ class DomeWindScreen(Dome):
 
     Altitudes are in decimal degrees, horizon = 0 and zenith = 90.
 
-    When the dome is in L{Mode.Track} and the 'screen_track' config option is
-    set, the screen follows the telescope altitude plus 'screen_offset',
-    clamped to ['screen_min_alt', 'screen_max_alt'].
+    When the dome is in L{Mode.Track} and the 'wind_screen_track' config option is
+    set, the wind screen follows the telescope altitude plus 'wind_screen_offset',
+    clamped to ['wind_screen_min_alt', 'wind_screen_max_alt'].
     """
 
-    def move_screen(self, alt: float) -> None:
+    def move_wind_screen(self, alt: float) -> None:
         """
         Move the wind screen to the given altitude.
 
-        The request is accepted with the slit closed as well: the screen must be
+        The request is accepted with the slit closed as well: the wind screen must be
         at the requested altitude by the time the slit opens.
 
-        @param alt: Screen altitude in decimal degrees.
+        @param alt: Wind screen altitude in decimal degrees.
         @type  alt: float
 
         @raises InvalidDomePositionException: When the requested altitude is
-        outside the screen travel limits.
+        outside the wind screen travel limits.
 
         @rtype: None
         """
 
-    def get_screen(self) -> float:
+    def get_wind_screen_alt(self) -> float:
         """
         Get the current wind screen altitude.
 
-        @return: Screen current altitude in decimal degrees.
+        @return: Wind screen current altitude in decimal degrees.
         @rtype: float
         """
         ...
 
-    def is_screen_moving(self) -> bool:
+    def is_wind_screen_moving(self) -> bool:
         """
         Ask if the wind screen is moving right now.
 
-        @return: True if the screen is moving, False otherwise.
+        @return: True if the wind screen is moving, False otherwise.
         @rtype: bool
         """
         ...
 
-    def abort_screen(self) -> None:
+    def abort_wind_screen_move(self) -> None:
         """
-        Try to abort the current screen movement.
+        Try to abort the current wind screen movement.
 
         @rtype: None
         """
 
     @event
-    def screen_begin(self, alt: float) -> None:
+    def wind_screen_move_begin(self, alt: float) -> None:
         """
-        Indicates that a new screen movement started.
+        Indicates that a new wind screen movement started.
 
-        @param alt: The screen altitude when the movement started, in decimal
+        @param alt: The wind screen altitude when the movement started, in decimal
         degrees.
         @type  alt: float
         """
 
     @event
-    def screen_complete(self, alt: float, status: DomeStatus) -> None:
+    def wind_screen_move_complete(self, alt: float, status: DomeStatus) -> None:
         """
-        Indicates that the last screen movement finished (with or without
+        Indicates that the last wind screen movement finished (with or without
         success, check L{status} field for more information.).
 
-        @param alt: The screen altitude when the movement finished, in decimal
+        @param alt: The wind screen altitude when the movement finished, in decimal
         degrees.
         @type  alt: float
 
-        @param status: Status of the screen command
+        @param status: Status of the wind screen command
         @type  status: L{DomeStatus}
         """
 

--- a/src/chimera/interfaces/dome.py
+++ b/src/chimera/interfaces/dome.py
@@ -221,7 +221,7 @@ class DomeSlit(Dome):
 
 class DomeFlap(Dome):
     """
-    Dome with Slit
+    Dome with Flap
     """
 
     def open_flap(self) -> None:
@@ -263,6 +263,43 @@ class DomeFlap(Dome):
 
         @param az: The azimuth when the flap closed.
         @type  az: float
+        """
+
+
+class DomeWindScreen(Dome):
+    """
+    Dome with Wind Screen
+    """
+
+    def move_screen(self, alt: float) -> None:
+        """
+        Move wind screen to an angle
+
+        @param alt: Windscreen altitude to move to
+        @type  alt: float
+        """
+
+    def get_screen(self) -> float:
+        """
+        Get current wind screen altitude
+
+        @return: Current windscreen altitude
+        @rtype: float
+        """
+
+    @event
+    def windscren_begin(self) -> None:
+        """
+        Event sent when windscreen starts moving
+        """
+
+    @event
+    def windscreen_complete(self, status: DomeStatus = DomeStatus.OK) -> None:
+        """
+        Event when windscreen finished moving
+
+        @param status: Status after windscreen command
+        @type  status: L{DomeStatus}
         """
 
 

--- a/src/chimera/interfaces/dome.py
+++ b/src/chimera/interfaces/dome.py
@@ -300,8 +300,7 @@ class DomeWindScreen(Dome):
     Dome with a wind screen: a screen that shades the lower part of the slit and
     is positioned in altitude.
 
-    Altitudes are in decimal degrees, horizon = 0 and zenith = 90, the same
-    convention used by ASCOM's Dome.Altitude.
+    Altitudes are in decimal degrees, horizon = 0 and zenith = 90.
 
     When the dome is in L{Mode.Track} and the 'screen_track' config option is
     set, the screen follows the telescope altitude plus 'screen_offset',

--- a/src/chimera/interfaces/dome.py
+++ b/src/chimera/interfaces/dome.py
@@ -10,7 +10,18 @@ from chimera.core.exceptions import ChimeraException
 from chimera.core.interface import Interface
 from chimera.util.enum import Enum
 
-__all__ = ["Mode", "Style", "Dome", "InvalidDomePositionException"]
+__all__ = [
+    "Mode",
+    "Style",
+    "DomeStatus",
+    "Dome",
+    "DomeSlew",
+    "DomeSlit",
+    "DomeFlap",
+    "DomeWindScreen",
+    "DomeSync",
+    "InvalidDomePositionException",
+]
 
 
 class Mode(Enum):
@@ -268,37 +279,59 @@ class DomeFlap(Dome):
 
 class DomeWindScreen(Dome):
     """
-    Dome with Wind Screen
+    Dome with a wind screen: a screen that shades the lower part of the slit and
+    is positioned in altitude.
+
+    Altitudes are in decimal degrees, horizon = 0 and zenith = 90, the same
+    convention used by ASCOM's Dome.Altitude.
     """
 
     def move_screen(self, alt: float) -> None:
         """
-        Move wind screen to an angle
+        Move the wind screen to the given altitude.
 
-        @param alt: Windscreen altitude to move to
+        The request is accepted with the slit closed as well: the screen must be
+        at the requested altitude by the time the slit opens.
+
+        @param alt: Screen altitude in decimal degrees.
         @type  alt: float
+
+        @raises InvalidDomePositionException: When the requested altitude is
+        outside the screen travel limits.
+
+        @rtype: None
         """
 
     def get_screen(self) -> float:
         """
-        Get current wind screen altitude
+        Get the current wind screen altitude.
 
-        @return: Current windscreen altitude
+        @return: Screen current altitude in decimal degrees.
         @rtype: float
         """
+        ...
 
     @event
-    def windscren_begin(self) -> None:
+    def screen_begin(self, alt: float) -> None:
         """
-        Event sent when windscreen starts moving
+        Indicates that a new screen movement started.
+
+        @param alt: The screen altitude when the movement started, in decimal
+        degrees.
+        @type  alt: float
         """
 
     @event
-    def windscreen_complete(self, status: DomeStatus = DomeStatus.OK) -> None:
+    def screen_complete(self, alt: float, status: DomeStatus) -> None:
         """
-        Event when windscreen finished moving
+        Indicates that the last screen movement finished (with or without
+        success, check L{status} field for more information.).
 
-        @param status: Status after windscreen command
+        @param alt: The screen altitude when the movement finished, in decimal
+        degrees.
+        @type  alt: float
+
+        @param status: Status of the screen command
         @type  status: L{DomeStatus}
         """
 

--- a/tests/chimera/instruments/test_dome_wind_screen.py
+++ b/tests/chimera/instruments/test_dome_wind_screen.py
@@ -19,8 +19,13 @@ from chimera.interfaces.dome import (
     Mode,
 )
 
-METHODS = ["move_screen", "get_screen", "is_screen_moving", "abort_screen"]
-EVENTS = ["screen_begin", "screen_complete"]
+METHODS = [
+    "move_wind_screen",
+    "get_wind_screen_alt",
+    "is_wind_screen_moving",
+    "abort_wind_screen_move",
+]
+EVENTS = ["wind_screen_move_begin", "wind_screen_move_complete"]
 
 
 def _free_tcp_port():
@@ -75,56 +80,60 @@ def test_config_keys_resolve():
         dome[key]
 
 
-def test_move_screen(dome):
-    dome.move_screen(45.0)
-    assert dome.get_screen() == 45.0
-    assert not dome.is_screen_moving()
+def test_move_wind_screen(dome):
+    dome.move_wind_screen(45.0)
+    assert dome.get_wind_screen_alt() == 45.0
+    assert not dome.is_wind_screen_moving()
 
-    dome.move_screen(10.0)
-    assert dome.get_screen() == 10.0
+    dome.move_wind_screen(10.0)
+    assert dome.get_wind_screen_alt() == 10.0
 
 
-def test_move_screen_outside_limits():
+def test_move_wind_screen_outside_limits():
     # direct instance: the bus re-raises remote errors as plain Exception,
     # which would hide the exception type this asserts on
     dome = FakeDome()
 
     with pytest.raises(InvalidDomePositionException):
-        dome.move_screen(dome["screen_max_alt"] + 1)
+        dome.move_wind_screen(dome["wind_screen_max_alt"] + 1)
 
     with pytest.raises(InvalidDomePositionException):
-        dome.move_screen(dome["screen_min_alt"] - 1)
+        dome.move_wind_screen(dome["wind_screen_min_alt"] - 1)
 
 
-def test_abort_screen(dome):
+def test_abort_wind_screen_move(dome):
     completed = []
-    dome.screen_complete += lambda alt, status: completed.append((alt, status))
+    dome.wind_screen_move_complete += lambda alt, status: completed.append(
+        (alt, status)
+    )
 
-    mover = threading.Thread(target=dome.move_screen, args=(90.0,))
+    mover = threading.Thread(target=dome.move_wind_screen, args=(90.0,))
     mover.start()
 
-    while not dome.is_screen_moving():
+    while not dome.is_wind_screen_moving():
         time.sleep(0.05)
 
-    dome.abort_screen()
+    dome.abort_wind_screen_move()
     mover.join(timeout=10)
 
-    assert not dome.is_screen_moving()
-    assert 0.0 < dome.get_screen() < 90.0
+    assert not dome.is_wind_screen_moving()
+    assert 0.0 < dome.get_wind_screen_alt() < 90.0
 
     # events are delivered asynchronously over the bus
     deadline = time.time() + 10.0
     while not completed and time.time() < deadline:
         time.sleep(0.05)
-    assert completed[0] == (dome.get_screen(), DomeStatus.ABORTED)
+    assert completed[0] == (dome.get_wind_screen_alt(), DomeStatus.ABORTED)
 
 
 def test_screen_events(dome):
     begun, completed = [], []
-    dome.screen_begin += begun.append
-    dome.screen_complete += lambda alt, status: completed.append((alt, status))
+    dome.wind_screen_move_begin += begun.append
+    dome.wind_screen_move_complete += lambda alt, status: completed.append(
+        (alt, status)
+    )
 
-    dome.move_screen(30.0)
+    dome.move_wind_screen(30.0)
 
     deadline = time.time() + 10.0
     while not (begun and completed) and time.time() < deadline:
@@ -135,29 +144,29 @@ def test_screen_events(dome):
 
 
 def test_tracking_follows_the_telescope_altitude(dome):
-    dome["screen_offset"] = 5.0
-    assert dome._screen_target(40.0) == 45.0
+    dome["wind_screen_offset"] = 5.0
+    assert dome._wind_screen_target(40.0) == 45.0
 
     # never asks for a position outside the screen travel
-    assert dome._screen_target(89.0) == dome["screen_max_alt"]
-    assert dome._screen_target(-10.0) == dome["screen_min_alt"]
+    assert dome._wind_screen_target(89.0) == dome["wind_screen_max_alt"]
+    assert dome._wind_screen_target(-10.0) == dome["wind_screen_min_alt"]
 
 
 def test_tracking_respects_the_resolution_deadband(dome):
-    dome["screen_alt_resolution"] = 10.0
-    dome.move_screen(40.0)
+    dome["wind_screen_alt_resolution"] = 10.0
+    dome.move_wind_screen(40.0)
 
-    dome._move_screen_if_needed(45.0)
-    assert dome.get_screen() == 40.0  # within the deadband, no move
+    dome._move_wind_screen_if_needed(45.0)
+    assert dome.get_wind_screen_alt() == 40.0  # within the deadband, no move
 
-    dome._move_screen_if_needed(55.0)
-    assert dome.get_screen() == 55.0
+    dome._move_wind_screen_if_needed(55.0)
+    assert dome.get_wind_screen_alt() == 55.0
 
 
 def test_tracking_can_be_turned_off(dome):
-    dome["screen_track"] = False
-    dome._move_screen_if_needed(45.0)
-    assert dome.get_screen() == 0.0
+    dome["wind_screen_track"] = False
+    dome._move_wind_screen_if_needed(45.0)
+    assert dome.get_wind_screen_alt() == 0.0
 
 
 def test_control_loop_tracks_the_telescope(manager):
@@ -176,17 +185,17 @@ def test_control_loop_tracks_the_telescope(manager):
     )
     telescope = manager.add_class(FakeTelescope, "fake")
     dome = manager.add_class(FakeDome, "dome", {"telescope": "/FakeTelescope/fake"})
-    dome["screen_offset"] = 3.0
+    dome["wind_screen_offset"] = 3.0
 
     dome.track()
     assert dome.get_mode() == Mode.Track
 
     dome.control()
-    assert dome.get_screen() == telescope.get_alt() + 3.0
+    assert dome.get_wind_screen_alt() == telescope.get_alt() + 3.0
 
 
-def test_metadata_carries_the_screen_altitude(dome):
-    dome.move_screen(35.0)
+def test_metadata_carries_the_wind_screen_altitude(dome):
+    dome.move_wind_screen(35.0)
     metadata = dict((key, value) for key, value, _ in dome.get_metadata({}))
     assert metadata["DOME_WSC"] == "35.00"
 

--- a/tests/chimera/instruments/test_dome_windscreen.py
+++ b/tests/chimera/instruments/test_dome_windscreen.py
@@ -10,6 +10,7 @@ import pytest
 
 from chimera.core.bus import Bus
 from chimera.core.manager import Manager
+from chimera.instruments.dome import DomeBase
 from chimera.instruments.fakedome import FakeDome
 from chimera.interfaces.dome import (
     DomeStatus,
@@ -61,8 +62,11 @@ def test_reference_implementation_is_complete(name):
     assert callable(getattr(FakeDome(), name))
 
 
-def test_features_reports_the_wind_screen():
-    assert FakeDome().features("DomeWindScreen")
+def test_features_reports_the_optional_parts():
+    dome = FakeDome()
+    assert dome.features("DomeWindScreen")
+    assert dome.features("DomeFlap")
+    assert not DomeBase().features("DomeFlap")
 
 
 def test_config_keys_resolve():
@@ -199,9 +203,10 @@ def test_metadata_carries_the_flap_status(dome):
 
 
 def test_metadata_skips_the_flap_when_the_driver_has_none():
-    class SlitOnlyDome(FakeDome):
-        def is_flap_open(self):
-            raise NotImplementedError()
+    # DomeBase no longer claims DomeFlap: drivers with a flap mix it in
+    class SlitOnlyDome(DomeBase):
+        def is_slit_open(self):
+            return False
 
     metadata = dict((key, value) for key, value, _ in SlitOnlyDome().get_metadata({}))
     assert "DOME_FLP" not in metadata

--- a/tests/chimera/instruments/test_dome_windscreen.py
+++ b/tests/chimera/instruments/test_dome_windscreen.py
@@ -185,3 +185,24 @@ def test_metadata_carries_the_screen_altitude(dome):
     dome.move_screen(35.0)
     metadata = dict((key, value) for key, value, _ in dome.get_metadata({}))
     assert metadata["DOME_WSC"] == "35.00"
+
+
+def test_metadata_carries_the_flap_status(dome):
+    metadata = dict((key, value) for key, value, _ in dome.get_metadata({}))
+    assert metadata["DOME_FLP"] == "Closed"
+
+    dome.open_slit()
+    dome.open_flap()
+
+    metadata = dict((key, value) for key, value, _ in dome.get_metadata({}))
+    assert metadata["DOME_FLP"] == "Open"
+
+
+def test_metadata_skips_the_flap_when_the_driver_has_none():
+    class SlitOnlyDome(FakeDome):
+        def is_flap_open(self):
+            raise NotImplementedError()
+
+    metadata = dict((key, value) for key, value, _ in SlitOnlyDome().get_metadata({}))
+    assert "DOME_FLP" not in metadata
+    assert "DOME_SLT" in metadata

--- a/tests/chimera/instruments/test_dome_windscreen.py
+++ b/tests/chimera/instruments/test_dome_windscreen.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
+
+import inspect
+import socket
+import threading
+import time
+
+import pytest
+
+from chimera.core.bus import Bus
+from chimera.core.manager import Manager
+from chimera.instruments.fakedome import FakeDome
+from chimera.interfaces.dome import (
+    DomeStatus,
+    DomeWindScreen,
+    InvalidDomePositionException,
+    Mode,
+)
+
+METHODS = ["move_screen", "get_screen", "is_screen_moving", "abort_screen"]
+EVENTS = ["screen_begin", "screen_complete"]
+
+
+def _free_tcp_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture
+def manager():
+    # local fixture on purpose: events need a live bus, and the shared one
+    # in tests/chimera/conftest.py still uses the pre-bus Manager() API
+    bus = Bus(f"tcp://127.0.0.1:{_free_tcp_port()}")
+    bus_thread = threading.Thread(target=bus.run_forever, name="Bus", daemon=True)
+    bus_thread.start()
+    manager = Manager(bus=bus)
+    yield manager
+    manager.shutdown()
+    bus.shutdown()
+    bus_thread.join(timeout=10)
+
+
+@pytest.fixture
+def dome(manager):
+    return manager.add_class(FakeDome, "dome", {"telescope": "/FakeTelescope/0"})
+
+
+@pytest.mark.parametrize("name", METHODS)
+def test_signature_matches_the_interface(name):
+    # plugins are written against these signatures; drifting them silently
+    # breaks every out-of-tree implementation
+    assert inspect.signature(getattr(FakeDome, name)) == inspect.signature(
+        getattr(DomeWindScreen, name)
+    )
+
+
+@pytest.mark.parametrize("name", METHODS + EVENTS)
+def test_reference_implementation_is_complete(name):
+    assert callable(getattr(FakeDome(), name))
+
+
+def test_features_reports_the_wind_screen():
+    assert FakeDome().features("DomeWindScreen")
+
+
+def test_config_keys_resolve():
+    dome = FakeDome()
+    for key in DomeWindScreen.__config__:
+        dome[key]
+
+
+def test_move_screen(dome):
+    dome.move_screen(45.0)
+    assert dome.get_screen() == 45.0
+    assert not dome.is_screen_moving()
+
+    dome.move_screen(10.0)
+    assert dome.get_screen() == 10.0
+
+
+def test_move_screen_outside_limits():
+    # direct instance: the bus re-raises remote errors as plain Exception,
+    # which would hide the exception type this asserts on
+    dome = FakeDome()
+
+    with pytest.raises(InvalidDomePositionException):
+        dome.move_screen(dome["screen_max_alt"] + 1)
+
+    with pytest.raises(InvalidDomePositionException):
+        dome.move_screen(dome["screen_min_alt"] - 1)
+
+
+def test_abort_screen(dome):
+    completed = []
+    dome.screen_complete += lambda alt, status: completed.append((alt, status))
+
+    mover = threading.Thread(target=dome.move_screen, args=(90.0,))
+    mover.start()
+
+    while not dome.is_screen_moving():
+        time.sleep(0.05)
+
+    dome.abort_screen()
+    mover.join(timeout=10)
+
+    assert not dome.is_screen_moving()
+    assert 0.0 < dome.get_screen() < 90.0
+
+    # events are delivered asynchronously over the bus
+    deadline = time.time() + 10.0
+    while not completed and time.time() < deadline:
+        time.sleep(0.05)
+    assert completed[0] == (dome.get_screen(), DomeStatus.ABORTED)
+
+
+def test_screen_events(dome):
+    begun, completed = [], []
+    dome.screen_begin += begun.append
+    dome.screen_complete += lambda alt, status: completed.append((alt, status))
+
+    dome.move_screen(30.0)
+
+    deadline = time.time() + 10.0
+    while not (begun and completed) and time.time() < deadline:
+        time.sleep(0.05)
+
+    assert begun == [0.0]  # altitude when the movement started
+    assert completed == [(30.0, DomeStatus.OK)]
+
+
+def test_tracking_follows_the_telescope_altitude(dome):
+    dome["screen_offset"] = 5.0
+    assert dome._screen_target(40.0) == 45.0
+
+    # never asks for a position outside the screen travel
+    assert dome._screen_target(89.0) == dome["screen_max_alt"]
+    assert dome._screen_target(-10.0) == dome["screen_min_alt"]
+
+
+def test_tracking_respects_the_resolution_deadband(dome):
+    dome["screen_alt_resolution"] = 10.0
+    dome.move_screen(40.0)
+
+    dome._move_screen_if_needed(45.0)
+    assert dome.get_screen() == 40.0  # within the deadband, no move
+
+    dome._move_screen_if_needed(55.0)
+    assert dome.get_screen() == 55.0
+
+
+def test_tracking_can_be_turned_off(dome):
+    dome["screen_track"] = False
+    dome._move_screen_if_needed(45.0)
+    assert dome.get_screen() == 0.0
+
+
+def test_control_loop_tracks_the_telescope(manager):
+    from chimera.core.site import Site
+    from chimera.instruments.faketelescope import FakeTelescope
+
+    manager.add_class(
+        Site,
+        "ufsc",
+        {
+            "name": "UFSC",
+            "latitude": "-27 36 13",
+            "longitude": "-48 31 20",
+            "altitude": "20",
+        },
+    )
+    telescope = manager.add_class(FakeTelescope, "fake")
+    dome = manager.add_class(FakeDome, "dome", {"telescope": "/FakeTelescope/fake"})
+    dome["screen_offset"] = 3.0
+
+    dome.track()
+    assert dome.get_mode() == Mode.Track
+
+    dome.control()
+    assert dome.get_screen() == telescope.get_alt() + 3.0
+
+
+def test_metadata_carries_the_screen_altitude(dome):
+    dome.move_screen(35.0)
+    metadata = dict((key, value) for key, value, _ in dome.get_metadata({}))
+    assert metadata["DOME_WSC"] == "35.00"


### PR DESCRIPTION
Declares the wind-screen dome role next to DomeSlit/DomeFlap: a screen positioned in altitude, in decimal degrees with horizon = 0 and zenith = 90. Also corrects the DomeFlap docstring ('Dome with Slit' -> 'Dome with Flap').

**Interface** — `move_screen(alt)`, `get_screen()`, `is_screen_moving()`, `abort_screen()`, plus the `screen_begin(alt)` / `screen_complete(alt, status)` events. A move takes tens of seconds, so callers need the motion state to wait on it and the abort to stop it — without an abort, `screen_complete(ABORTED)` was unreachable. A position request is accepted with the slit closed and applied by the time it opens.

**Config** (in both `DomeConfig` and `__config__`): `screen_track`, `screen_offset`, `screen_min_alt`/`screen_max_alt`, `screen_alt_resolution`, `screen_park_position`, `screen_timeout`.

**Base implementation** — while the dome is in Track mode, the control loop keeps the screen at telescope altitude + `screen_offset`, clamped to the travel limits and deadbanded by `screen_alt_resolution`; `park_on_shutdown` stows the screen; `get_metadata` writes `DOME_WSC`, alongside a new `DOME_FLP` flap key. All of it is guarded by `features("DomeWindScreen")` — `DomeBase` does not inherit the interface, drivers opt in by mixing it in.

**Driver and CLI** — `FakeDome` is the reference implementation (timed move, honours abort, reports `ABORTED`). `chimera-dome` gains `--move-screen ALT`, prints the screen altitude in `--info` and aborts the screen on ^C. 21 tests cover signature conformance against the interface, the move/limits/abort lifecycle, event payloads, tracking (target, deadband, opt-out) and the control-loop integration.

No hardware driver implements it yet: the LNA 40 cm dome has no wind screen. The closest real target is the LCO Swope TCS, whose screen is jog-based (`SCREENPOS GO UP|DOWN|STOP` plus a position readout and a fully-open limit switch) — it would need `stop_screen()` and an `is_screen_open()`, left out of this PR.
