### PR TITLE
ci: upload coverage to codecov via OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
 env:
   RUFF_OUTPUT_FORMAT: github
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -29,7 +33,13 @@ jobs:
         run: uv run pre-commit run --all-files
 
       - name: test
-        run: uv run pytest
+        run: uv run pytest --cov-report=xml
+
+      - name: upload coverage to codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: coverage.xml
 
       - name: build
         run: uv build

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+coverage.xml
+htmlcov/
 .tox
 nosetests.xml
 


### PR DESCRIPTION
## Summary

CI already collects coverage on every run (`--cov=src/chimera --cov-branch` in `pyproject.toml`), but the report never left the runner. This uploads it to codecov.io so coverage is tracked over time and shown on PRs.

- The test step now runs `uv run pytest --cov-report=xml`, emitting an XML report in addition to the html report configured in `pyproject.toml`.
- New `codecov/codecov-action@v5` step uploads `coverage.xml` using **OIDC** (`use_oidc: true`) — no `CODECOV_TOKEN` secret to manage. This requires a workflow-level `permissions` block with `id-token: write` (plus an explicit `contents: read`, since declaring any permission drops the defaults).
- `fail_ci_if_error` stays at its default (`false`): fork PRs don't get OIDC tokens, so their uploads may fall through without breaking CI.
- `.gitignore` now covers `coverage.xml` and `htmlcov/` (the latter was already generated locally on every pytest run but never ignored).

## Prerequisite

OIDC uploads require the Codecov GitHub App to be installed for `astroufsc/chimera` (app.codecov.io → repo setup). Until then the upload step will be rejected (non-fatally).

## Test plan

- [x] `uv run pytest --cov-report=xml -k url` locally: 16 tests pass, `coverage.xml` and `htmlcov/` both produced
- [ ] CI run on this PR: `upload coverage to codecov` step succeeds and logs a codecov.io URL (needs the Codecov app installed first)