### PR TITLE
feat(core): inject a local Site into every managed object via get_site()

### DIFF
--- a/src/chimera/cli/chimera.py
+++ b/src/chimera/cli/chimera.py
@@ -15,7 +15,7 @@ import chimera.core.log
 from chimera.core.bus import Bus
 from chimera.core.chimera_config import ChimeraConfig
 from chimera.core.constants import CHIMERA_CONFIG_DEFAULT_FILENAME
-from chimera.core.exceptions import ChimeraException
+from chimera.core.exceptions import ChimeraException, OptionConversionException
 from chimera.core.manager import Manager
 from chimera.core.path import ChimeraPath
 from chimera.core.site import Site
@@ -115,9 +115,20 @@ class ChimeraCLI:
         log.info(f"Python: {platform.python_version()}")
         log.info(f"System: {platform.uname()}")
 
+        # create the site object shared by every managed object; the parser
+        # guarantees exactly one [site] entry
+        ((site_url, site_config),) = self.config.sites.items()
+        site = Site()
+        try:
+            for k, v in site_config.items():
+                site[k] = v
+        except (OptionConversionException, KeyError) as e:
+            log.error(f"There was a problem configuring the site {site_url}. ({e})")
+            sys.exit(1)
+
         try:
             self.bus = Bus(f"tcp://{self.options.host}:{self.options.port}")
-            self.manager = Manager(bus=self.bus)
+            self.manager = Manager(bus=self.bus, site=site)
         except ChimeraException:
             log.error(
                 "Chimera is already running on this machine. Use chimera-admin to manage it."
@@ -125,10 +136,6 @@ class ChimeraCLI:
             sys.exit(1)
 
         log.info(f"Chimera: running on {self.options.host}:{self.options.port}")
-
-        # add site object
-        for url, config in self.config.sites.items():
-            self.manager.add_class(Site, url.name, config, start=True)
 
         # init from config
         log.info("Starting instruments...")

--- a/src/chimera/cli/sched.py
+++ b/src/chimera/cli/sched.py
@@ -367,12 +367,6 @@ class ChimeraSched(ChimeraCLI):
                     else:
                         program.actions.append(Point(target_name=objname))
 
-                        # if imagetype == "FLAT":
-                        #     site = self._remote_manager.get_proxy("/Site/0")
-                        #     flat_position = Position.from_alt_az(site['flat_alt'], site['flat_az'])
-                        #     program.actions.append(Point(target_alt_az=flat_position))
-                        # TODO: point dome to its flat position too.
-
                 for exp in exps:
                     if exp.count(":") > 1:
                         filter, exptime, frames = exp.strip().split(":")

--- a/src/chimera/controllers/imageserver/imagerequest.py
+++ b/src/chimera/controllers/imageserver/imagerequest.py
@@ -129,10 +129,16 @@ class ImageRequest(dict):
     def _fetch_pre_headers(self, chimera_obj):
         auto = []
         if self.auto_collect_metadata:
+            # site metadata comes from the local injected instance, first so
+            # FITS header order is preserved
+            try:
+                self.headers += chimera_obj.get_site().get_metadata(self)
+            except Exception:
+                log.warning("Unable to get metadata from site")
+
             auto += [
                 f"/{cls}/0"
                 for cls in (
-                    "Site",
                     "Camera",
                     "Dome",
                     "FilterWheel",

--- a/src/chimera/controllers/scheduler/controller.py
+++ b/src/chimera/controllers/scheduler/controller.py
@@ -33,7 +33,6 @@ class Scheduler(ChimeraObject):
         "autoguider": "/Autoguider/0",
         "point_verify": "/PointVerify/0",
         "operator": "/Operator/0",
-        "site": "/Site/0",
         "algorithm": SchedulingAlgorithm.SEQUENTIAL,
     }
 

--- a/src/chimera/controllers/scheduler/machine.py
+++ b/src/chimera/controllers/scheduler/machine.py
@@ -122,8 +122,9 @@ class Machine(threading.Thread):
 
             log.debug(f"[start] {str(task)}")
 
-            # the configured site, not a private Site(): one clock system-wide
-            site = self.controller.get_proxy(self.controller["site"])
+            # the manager-injected site, not a private Site(): one clock
+            # system-wide
+            site = self.controller.get_site()
             now_mjd = site.mjd()
             log.debug("[start] Current MJD is %f", now_mjd)
             if program.start_at:

--- a/src/chimera/core/chimeraobject.py
+++ b/src/chimera/core/chimeraobject.py
@@ -4,6 +4,7 @@
 import logging
 import threading
 import time
+from typing import TYPE_CHECKING
 
 from chimera.core.bus import Bus
 from chimera.core.config import Config
@@ -14,12 +15,16 @@ from chimera.core.constants import (
     METHODS_ATTRIBUTE_NAME,
     RWLOCK_ATTRIBUTE_NAME,
 )
+from chimera.core.exceptions import ObjectNotFoundException
 from chimera.core.metaobject import MetaObject
 from chimera.core.proxy import Proxy
 from chimera.core.rwlock import ReadWriteLock
 from chimera.core.state import State
 from chimera.core.url import URL, parse_url
 from chimera.interfaces.lifecycle import ILifeCycle
+
+if TYPE_CHECKING:
+    from chimera.core.site import Site
 
 __all__ = ["ChimeraObject"]
 
@@ -45,6 +50,7 @@ class ChimeraObject(ILifeCycle, metaclass=MetaObject):
 
         self.__location__: URL
         self.__bus__: Bus
+        self.__site__: Site | None = None
 
         # logging.
         # put every logger on behalf of chimera's logger so
@@ -221,6 +227,13 @@ class ChimeraObject(ILifeCycle, metaclass=MetaObject):
         :return: True if is instance, False otherwise
         """
         return any(interface == cls.__name__ for cls in self.__class__.__mro__)
+
+    def get_site(self) -> "Site":
+        if self.__site__ is None:
+            raise ObjectNotFoundException(
+                "no site available: object is not registered with a Manager that has a Site"
+            )
+        return self.__site__
 
     def get_proxy(self, url: str | None = None) -> Proxy:
         if url is not None:

--- a/src/chimera/core/manager.py
+++ b/src/chimera/core/manager.py
@@ -29,6 +29,7 @@ from chimera.core.exceptions import (
 )
 from chimera.core.proxy import Proxy
 from chimera.core.resources import ResourcesManager
+from chimera.core.site import Site
 from chimera.core.state import State
 from chimera.core.url import URL, parse_url, resolve_url
 from chimera.core.version import chimera_version
@@ -68,11 +69,13 @@ class Manager:
     @group Shutdown: wait, shutdown
     """
 
-    def __init__(self, bus: Bus):
+    def __init__(self, bus: Bus, site: Site | None = None):
         log.info("Starting manager.")
 
         self._bus = bus
         self._bus.resolve_request = self._resolve_request
+
+        self.site = site
 
         self.resources = ResourcesManager()
         self.class_loader = ClassLoader()
@@ -85,6 +88,11 @@ class Manager:
 
         # register ourselves
         self.resources.add("/Manager/manager", self)
+
+        # register the site as a regular resource so it stays reachable
+        # over a Proxy (e.g. for remote config changes)
+        if site is not None:
+            self.add_object(site, site["name"], start=True)
 
     def _resolve_request(
         self, object: str, method: str
@@ -350,19 +358,6 @@ class Manager:
         @rtype: Proxy or bool
         """
 
-        url = self._resolve_location(f"/{cls.__name__}/{name}")
-
-        # names must not start with a digit
-        if url.name[0] in "0123456789":
-            raise InvalidLocationException(
-                f"Invalid instance name: {url.name} (must start with a letter)"
-            )
-
-        if url.path in self.resources:
-            raise InvalidLocationException(
-                f"Location {url.path} is already in the system. Only one allowed (Tip: change the name!)."
-            )
-
         # check if it's a valid ChimeraObject
         if not issubclass(cls, ChimeraObject):
             raise NotValidChimeraObjectException(
@@ -375,8 +370,59 @@ class Manager:
         try:
             obj = cls()
         except Exception:
-            log.exception(f"Error in {url} __init__.")
-            raise ChimeraObjectException(f"Error in {url} __init__.")
+            log.exception(f"Error in /{cls.__name__}/{name} __init__.")
+            raise ChimeraObjectException(f"Error in /{cls.__name__}/{name} __init__.")
+
+        return self.add_object(obj, name, config, start)
+
+    def add_object(
+        self,
+        obj: ChimeraObject,
+        name: str,
+        config: dict[str, Any] | None = None,
+        start: bool = True,
+    ):
+        """
+        Add an already-constructed ChimeraObject instance to the system,
+        configuring it using 'config'.
+
+        @param obj: The instance to add to the system.
+        @type obj: ChimeraObject
+
+        @param name: The name of the instance.
+        @type name: str
+
+        @param config: The configuration dictionary for the object.
+        @type config: dict
+
+        @param start: start the object after initialization.
+        @type start: bool
+
+        @raises ChimeraObjectException: Internal error on managed (user) object.
+        @raises NotValidChimeraObjectException: When an object which doesn't inherit from ChimeraObject is given.
+        @raises InvalidLocationException: When the requested location is invalid.
+
+        @return: returns a proxy for the object if successful.
+        @rtype: Proxy
+        """
+
+        if not isinstance(obj, ChimeraObject):
+            raise NotValidChimeraObjectException(
+                f"Cannot add {obj!r}. It doesn't descend from ChimeraObject."
+            )
+
+        url = self._resolve_location(f"/{type(obj).__name__}/{name}")
+
+        # names must not start with a digit
+        if url.name[0] in "0123456789":
+            raise InvalidLocationException(
+                f"Invalid instance name: {url.name} (must start with a letter)"
+            )
+
+        if url.path in self.resources:
+            raise InvalidLocationException(
+                f"Location {url.path} is already in the system. Only one allowed (Tip: change the name!)."
+            )
 
         try:
             for k, v in list((config or {}).items()):
@@ -388,6 +434,7 @@ class Manager:
         # connect
         obj.__location__ = url
         obj.__bus__ = self._bus
+        obj.__site__ = self.site
         self.resources.add(url.path, obj)
 
         if start:

--- a/src/chimera/core/site.py
+++ b/src/chimera/core/site.py
@@ -3,6 +3,7 @@
 
 
 import datetime as dt
+import threading
 
 import ephem
 from dateutil import tz
@@ -15,6 +16,16 @@ __all__ = ["Site"]
 
 
 class Site(ChimeraObject):
+    """
+    Site-related information: coordinates, clocks (including the
+    fast-forward simulation clock), sidereal time and sun/moon ephemeris.
+
+    A single instance is shared in-process by every managed object through
+    ChimeraObject.get_site(), so its methods are called concurrently from
+    many threads. Config access is rwlock-guarded; the shared ephem state
+    is NOT (see the NOTEs below).
+    """
+
     __config__ = dict(
         name="UFSC",
         latitude=Coord.from_dms("-23 00 00"),
@@ -36,10 +47,14 @@ class Site(ChimeraObject):
     def __init__(self):
         super().__init__()
 
+        # NOTE(thread-safety): shared mutable pyephem bodies. compute() and
+        # next_rising/next_setting() mutate them in place, so concurrent
+        # calls to the sun/moon methods race on these objects.
         self._sun = ephem.Sun()
         self._moon = ephem.Moon()
 
         # fast-forward clock anchors, captured on the first ut() call
+        self._ff_lock = threading.Lock()
         self._ff_wall0 = None
         self._ff_sim0 = None
 
@@ -85,18 +100,24 @@ class Site(ChimeraObject):
     def ut(self):
         if not self._fast_forward_enabled():
             return dt.datetime.now(tz.tzutc())
-        # scaled simulation clock (see __config__): anchor on the first call
+        # scaled simulation clock (see __config__): anchor on the first call.
+        # Double-checked locking: anchors are write-once, so once _ff_wall0
+        # is visible the lock-free fast path below is safe.
         wall_now = dt.datetime.now(tz.tzutc())
         if self._ff_wall0 is None:
-            self._ff_wall0 = wall_now
-            start = str(self["time_start"]).strip()
-            if start:
-                sim0 = dt.datetime.fromisoformat(start)
-                if sim0.tzinfo is None:
-                    sim0 = sim0.replace(tzinfo=tz.tzutc())
-                self._ff_sim0 = sim0.astimezone(tz.tzutc())
-            else:
-                self._ff_sim0 = wall_now
+            with self._ff_lock:
+                if self._ff_wall0 is None:
+                    start = str(self["time_start"]).strip()
+                    if start:
+                        sim0 = dt.datetime.fromisoformat(start)
+                        if sim0.tzinfo is None:
+                            sim0 = sim0.replace(tzinfo=tz.tzutc())
+                        self._ff_sim0 = sim0.astimezone(tz.tzutc())
+                    else:
+                        self._ff_sim0 = wall_now
+                    # set last: readers test _ff_wall0, so _ff_sim0 must
+                    # already be in place when they see it non-None
+                    self._ff_wall0 = wall_now
         elapsed = (wall_now - self._ff_wall0).total_seconds() * self["time_speedup"]
         return self._ff_sim0 + dt.timedelta(seconds=elapsed)
 
@@ -129,6 +150,9 @@ class Site(ChimeraObject):
         gst = (lst - self["longitude"].to_h()) % Coord.from_h(24)
         return gst
 
+    # NOTE(thread-safety): the rise/set/twilight family below passes the
+    # shared _sun/_moon bodies into next_rising/next_setting, which mutate
+    # them — concurrent callers race on the shared body.
     def sunrise(self, date=None):
         date = date or self.ut()
         site = self._get_ephem(date)
@@ -169,6 +193,8 @@ class Site(ChimeraObject):
         return self._date_to_local(site.next_rising(self._sun))
 
     def sunpos(self, date=None):
+        # NOTE(thread-safety): compute-then-read on the shared _sun body is
+        # not atomic; a concurrent sun method can recompute it in between.
         date = date or self.ut()
         self._sun.compute(self._get_ephem(date))
 
@@ -221,6 +247,8 @@ class Site(ChimeraObject):
         return self._date_to_local(site.next_setting(self._moon))
 
     def moonpos(self, date=None):
+        # NOTE(thread-safety): compute-then-read race on the shared _moon
+        # body, same as sunpos.
         date = date or self.ut()
         self._moon.compute(self._get_ephem(date))
 
@@ -229,6 +257,8 @@ class Site(ChimeraObject):
         )
 
     def moonphase(self, date=None):
+        # NOTE(thread-safety): compute-then-read race on the shared _moon
+        # body, same as sunpos.
         date = date or self.ut()
         self._moon.compute(self._get_ephem(date))
         return self._moon.phase / 100.0

--- a/src/chimera/instruments/faketelescope.py
+++ b/src/chimera/instruments/faketelescope.py
@@ -40,15 +40,11 @@ class FakeTelescope(TelescopeBase, TelescopePier):
         self._az: float = 0.0
 
     def _set_alt_az_from_ra_dec(self):
-        self._alt, self._az = self._get_site().ra_dec_to_alt_az(self._ra, self._dec)
-
-    def _get_site(self):
-        # FIXME: create the proxy directly and cache it
-        return self.get_proxy("/Site/0")
+        self._alt, self._az = self.get_site().ra_dec_to_alt_az(self._ra, self._dec)
 
     def _set_ra_dec_from_alt_az(self):
         # alt, az in degrees
-        self._ra, self._dec = self._get_site().alt_az_to_ra_dec(self._alt, self._az)
+        self._ra, self._dec = self.get_site().alt_az_to_ra_dec(self._alt, self._az)
 
     def __start__(self):
         self.set_hz(1)
@@ -113,7 +109,7 @@ class FakeTelescope(TelescopeBase, TelescopePier):
     def slew_to_alt_az(self, alt: float, az: float):
         self._validate_alt_az(alt, az)
 
-        ra, dec = self._get_site().alt_az_to_ra_dec(alt, az)
+        ra, dec = self.get_site().alt_az_to_ra_dec(alt, az)
         self.slew_begin(ra, dec)
 
         alt_steps = (alt - self.get_alt()) / 10

--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -2,12 +2,9 @@
 # SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
 
 
-from typing import cast
-
 from chimera.core.chimeraobject import ChimeraObject
 from chimera.core.exceptions import ObjectNotFoundException, ObjectTooLowException
 from chimera.core.lock import lock
-from chimera.core.site import Site
 from chimera.interfaces.telescope import (
     TelescopePark,
     TelescopeSlew,
@@ -29,11 +26,6 @@ class TelescopeBase(
 
         self._park_position = None
 
-    # @property
-    # @functools.cache
-    def site(self) -> Site:
-        return cast(Site, self.get_proxy("/Site/0"))
-
     @lock
     def slew_to_object(self, name):
         _, ra, dec, epoch = simbad_lookup(name) or (None, None, None, None)
@@ -47,8 +39,9 @@ class TelescopeBase(
 
     def _validate_ra_dec(self, ra: float, dec: float):
         # TODO: remove Position dependency
-        lst = self.site().lst_in_rads()  # in radians
-        latitude = self.site().latitude_in_degs()
+        site = self.get_site()
+        lst = site.lst_in_rads()  # in radians
+        latitude = site.latitude_in_degs()
 
         alt, az = Position.ra_dec_to_alt_az(ra, dec, latitude, lst)
 

--- a/src/chimera/interfaces/autoflat.py
+++ b/src/chimera/interfaces/autoflat.py
@@ -31,7 +31,6 @@ class IAutoFlat(Interface):
         "dome": "/Dome/0",
         "camera": "/Camera/0",
         "filterwheel": "/FilterWheel/0",
-        "site": "/Site/0",
     }
 
     def get_flats(self, filter_id, n_flats):

--- a/tests/chimera/conftest.py
+++ b/tests/chimera/conftest.py
@@ -6,6 +6,7 @@ import pytest
 
 from chimera.core.bus import Bus
 from chimera.core.manager import Manager
+from chimera.core.site import Site
 
 
 @pytest.fixture
@@ -33,7 +34,16 @@ def manager():
     bus_thread.start()
     assert bus._bus_started.wait(5)
 
-    manager = Manager(bus)
+    site = Site()
+    for k, v in {
+        "name": "lna",
+        "latitude": "-27 36 13",
+        "longitude": "-48 31 20",
+        "altitude": "20",
+    }.items():
+        site[k] = v
+
+    manager = Manager(bus, site=site)
 
     yield manager
 

--- a/tests/chimera/core/test_site.py
+++ b/tests/chimera/core/test_site.py
@@ -8,29 +8,11 @@ import msgspec
 import pytest
 from dateutil.relativedelta import relativedelta
 
-from chimera.core.site import Site
-
-SITE_CONFIG = {
-    "name": "UFSC",
-    "latitude": "-27 36 13 ",
-    "longitude": "-48 31 20",
-    "altitude": "20",
-}
-
 
 class TestSite:
+    # the manager fixture injects a local Site; these tests keep using the
+    # proxy on purpose: the site must stay reachable over the bus
     def test_times(self, manager):
-        manager.add_class(
-            Site,
-            "lna",
-            {
-                "name": "UFSC",
-                "latitude": "-27 36 13 ",
-                "longitude": "-48 31 20",
-                "altitude": "20",
-            },
-        )
-
         site = manager.get_proxy("/Site/0")
 
         print()
@@ -40,17 +22,6 @@ class TestSite:
 
     @pytest.mark.skip
     def test_sidereal_clock(self, manager):
-        manager.add_class(
-            Site,
-            "lna",
-            {
-                "name": "UFSC",
-                "latitude": "-27 36 13 ",
-                "longitude": "-48 31 20",
-                "altitude": "20",
-            },
-        )
-
         site = manager.get_proxy("/Site/0")
 
         times = []
@@ -68,17 +39,6 @@ class TestSite:
         print(sum(real_times) / len(real_times))
 
     def test_astros(self, manager):
-        manager.add_class(
-            Site,
-            "lna",
-            {
-                "name": "UFSC",
-                "latitude": "-27 36 13 ",
-                "longitude": "-48 31 20",
-                "altitude": "20",
-            },
-        )
-
         site = manager.get_proxy("/Site/0")
 
         print()
@@ -115,7 +75,6 @@ class TestSite:
         print("sunrise twilight duration      :", sunrise_twilight_duration)
 
     def test_sun_altitude_is_the_altitude_in_degrees(self, manager):
-        manager.add_class(Site, "lna", SITE_CONFIG)
         site = manager.get_proxy("/Site/0")
 
         when = dt.datetime(2026, 7, 27, 16, 0, tzinfo=dt.UTC)
@@ -126,7 +85,6 @@ class TestSite:
     def test_sun_altitude_survives_the_bus(self, manager):
         """A Position cannot be encoded, so sunpos() only works between
         objects sharing a bus - the reason for a plain-float accessor."""
-        manager.add_class(Site, "lna", SITE_CONFIG)
         site = manager.get_proxy("/Site/0")
 
         encoder = msgspec.json.Encoder()
@@ -138,7 +96,6 @@ class TestSite:
     def test_is_dusk_tracks_the_sun_not_the_clock(self, manager):
         """Dusk is the sun on its way down, sampled all the way around a
         day and checked against the altitude it is about to have."""
-        manager.add_class(Site, "lna", SITE_CONFIG)
         site = manager.get_proxy("/Site/0")
 
         midnight = dt.datetime(2026, 7, 27, 0, 0, tzinfo=dt.UTC)

--- a/tests/chimera/core/test_site_injection.py
+++ b/tests/chimera/core/test_site_injection.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
+
+import pytest
+
+from chimera.core.exceptions import ObjectNotFoundException
+from chimera.instruments.fakerotator import FakeRotator
+from chimera.util.coord import Coord
+
+
+class TestSiteInjection:
+    def test_get_site_returns_shared_local_instance(self, manager):
+        manager.add_class(FakeRotator, "r1", start=False)
+        manager.add_class(FakeRotator, "r2", start=False)
+
+        r1 = manager.resources.get("/FakeRotator/r1").instance
+        r2 = manager.resources.get("/FakeRotator/r2").instance
+
+        assert r1.get_site() is manager.site
+        assert r2.get_site() is manager.site
+
+    def test_site_gets_itself_injected(self, manager):
+        assert manager.site.get_site() is manager.site
+
+    def test_unregistered_object_raises(self):
+        rotator = FakeRotator()
+        with pytest.raises(ObjectNotFoundException):
+            rotator.get_site()
+
+    def test_site_still_reachable_over_proxy(self, manager):
+        assert "/Site/lna" in manager.resources
+
+        proxy = manager.get_proxy("/Site/0")
+        assert isinstance(proxy.mjd(), float)
+
+    def test_remote_config_change_visible_locally(self, manager):
+        proxy = manager.get_proxy("/Site/0")
+        proxy["latitude"] = "-30 00 00"
+
+        assert manager.site["latitude"] == Coord.from_dms("-30 00 00")
+
+        manager.add_class(FakeRotator, "fake", start=False)
+        rotator = manager.resources.get("/FakeRotator/fake").instance
+        assert rotator.get_site()["latitude"] == Coord.from_dms("-30 00 00")

--- a/tests/chimera/instruments/test_dome.py
+++ b/tests/chimera/instruments/test_dome.py
@@ -10,7 +10,6 @@ import time
 import pytest
 
 import chimera.core.log
-from chimera.core.site import Site
 from chimera.instruments.fakedome import FakeDome
 from chimera.instruments.faketelescope import FakeTelescope
 from chimera.interfaces.dome import DomeStatus
@@ -46,17 +45,7 @@ def assert_dome_az(dome_az, other_az, eps):
 
 @pytest.fixture
 def dome(manager):
-    manager.add_class(
-        Site,
-        "lna",
-        {
-            "name": "UFSC",
-            "latitude": "-27 36 13 ",
-            "longitude": "-48 31 20",
-            "altitude": "20",
-        },
-    )
-
+    # the manager fixture provides the injected site
     manager.add_class(FakeTelescope, "fake")
     manager.add_class(
         FakeDome, "dome", {"telescope": "/FakeTelescope/0", "mode": "Track"}

--- a/tests/chimera/instruments/test_rotator.py
+++ b/tests/chimera/instruments/test_rotator.py
@@ -3,7 +3,6 @@
 
 import pytest
 
-from chimera.core.site import Site
 from chimera.instruments.fakerotator import FakeRotator
 
 
@@ -16,19 +15,7 @@ class TestRotator:
     @pytest.fixture(autouse=True)
     def setup(self, manager):
         """Setup fixture called before each test."""
-        # Add site configuration
-        manager.add_class(
-            Site,
-            "lna",
-            {
-                "name": "UFSC",
-                "latitude": "-27 36 13",
-                "longitude": "-48 31 20",
-                "altitude": "20",
-            },
-        )
-
-        # Add FakeRotator
+        # the manager fixture provides the injected site
         manager.add_class(FakeRotator, "fake")
         self.rotator = manager.get_proxy("/FakeRotator/0")
 

--- a/tests/chimera/instruments/test_telescope.py
+++ b/tests/chimera/instruments/test_telescope.py
@@ -10,7 +10,6 @@ from concurrent.futures import ThreadPoolExecutor, wait
 import pytest
 
 import chimera.core.log
-from chimera.core.site import Site
 from chimera.instruments.faketelescope import FakeTelescope
 from chimera.interfaces.telescope import TelescopeStatus
 from chimera.util.coord import Coord
@@ -44,17 +43,8 @@ def slew_complete_callback(ra, dec, status):
 
 @pytest.fixture
 def telescope(manager):
-    manager.add_class(
-        Site,
-        "lna",
-        {
-            "name": "UFSC",
-            "latitude": "-27 36 13",
-            "longitude": "-48 31 20",
-            "altitude": "20",
-        },
-    )
-
+    # the manager fixture provides the injected site (latitude matches
+    # SITE_LATITUDE above)
     manager.add_class(FakeTelescope, "fake")
 
     fired_events.clear()


### PR DESCRIPTION
## Summary

`Site` info (clocks, LST, sun/moon) was only reachable through a Proxy, so every consumer paid a serialized bus round-trip even in-process — the scheduler polled `site.mjd()` once per second over the bus — and hardcoded `"/Site/0"` paths everywhere. It also left no cheap path for `Site` to expose the object hierarchy later (e.g. which telescope a camera is connected to).

- The server bootstrap (`cli/chimera.py`) now builds the one `Site` from the `[site]` config and passes it to `Manager(bus, site=...)`.
- `Manager.add_class` splits into instantiation plus a new `add_object()`, which injects `obj.__site__` alongside `__location__`/`__bus__` into everything it registers — including the Site itself.
- New `ChimeraObject.get_site()` returns that local instance, raising `ObjectNotFoundException` on objects not registered with a sited Manager.
- The Site stays registered as a regular resource, so `/Site/<name>` remains Proxy-reachable for remote config changes (covered by a new test).

Proxy accessors folded into `get_site()`: `TelescopeBase.site()`, `FakeTelescope._get_site()`, the scheduler machine's configured-site lookup, and imagerequest's site metadata fetch.

Since the instance is now called concurrently from many threads, `ut()`'s fast-forward clock anchors initialize under a lock; the shared `_sun`/`_moon` pyephem bodies remain unsafe and are flagged with `NOTE(thread-safety)` comments for a later pass.

## Breaking change

The now-dead `"site": "/Site/0"` config defaults are dropped from `Scheduler` and `IAutoFlat`. Out-of-tree plugins reading `self["site"]` must migrate to `self.get_site()`.

## Testing

- New `tests/chimera/core/test_site_injection.py`: shared instance across objects, Site self-injection, error on unregistered objects, Proxy path still working, remote config write via Proxy visible through `get_site()`.
- Test fixtures now get the site from the shared `manager` fixture instead of per-file `add_class(Site, ...)` blocks; `test_site.py` deliberately keeps using the Proxy to cover the remote path.
- Full suite green on this base (the only failure, `test_image.py::test_wcs`, fails identically on master — pre-existing astropy issue).
- Boot smoke test with the sample config: `/Site/CTIO` registers first, instruments and scheduler start, system up.