### PR TITLE
core: control loop survives exceptions from control()

### DIFF
--- a/src/chimera/core/chimeraobject.py
+++ b/src/chimera/core/chimeraobject.py
@@ -162,7 +162,13 @@ class ChimeraObject(ILifeCycle, metaclass=MetaObject):
             # control runs unlocked on its own thread: a long @lock method
             # (an exposure, a slew) must not stall the control loop. Keeping
             # control() thread-safe is the implementer's job.
-            run_condition = self.control()
+            try:
+                run_condition = self.control()
+            except Exception:
+                # an exception must not kill the loop: a dome that hiccups on
+                # one serial frame would otherwise silently stop tracking for
+                # the rest of the night. Log it and retry on the next cycle.
+                self.log.exception("control() raised; retrying next cycle")
             loop_time = time.monotonic() - t0
 
             time_to_wake_up = (1.0 / self.get_hz()) - loop_time

--- a/tests/chimera/core/test_chimera_object.py
+++ b/tests/chimera/core/test_chimera_object.py
@@ -183,6 +183,25 @@ class TestChimeraObject:
         assert m.__main__() is True
         assert m.counter == m.get_hz()
 
+    def test_main_survives_control_exceptions(self):
+        # one bad cycle (a flaky serial frame, an unreachable proxy) must not
+        # kill the control loop: the exception is logged and the loop retries
+        class FlakyControl(ChimeraObject):
+            def __init__(self):
+                ChimeraObject.__init__(self)
+                self.calls = 0
+
+            def control(self):
+                self.calls += 1
+                if self.calls == 1:
+                    raise RuntimeError("one bad serial frame")
+                return self.calls < 3
+
+        m = FlakyControl()
+        m.set_hz(100)
+        m.__main__()
+        assert m.calls == 3
+
     def test_location(self):
         class Foo(ChimeraObject):
             pass


### PR DESCRIPTION
Live failure, 2026-07-26 02:58 on the LNA 40 cm: one EMI-corrupted dome serial frame raised through `DomeBase._process_queue()` → `control()`, the manager logged "control loop died with an exception", and the dome silently stopped tracking for the rest of the night.

`__main__` now catches exceptions from `control()`, logs the traceback, and retries on the next cycle.

Scope notes, given the review on #261:
- Bus callers are unaffected — `sync_with_tel()` etc. still raise to their caller, so an exposure is still aborted rather than taken against a mispointed dome.
- Only the autonomous loop becomes immune to one bad cycle; a persistently failing `control()` logs on every cycle, so the failure stays visible.
- The manager-side "control loop died" log remains as a backstop for anything outside `control()`.

Test: `test_main_survives_control_exceptions` — a control() that raises on its first cycle keeps looping and completes.