### PR TITLE
fix Position.angsep for alt/az positions

### DIFF
--- a/src/chimera/util/position.py
+++ b/src/chimera/util/position.py
@@ -46,6 +46,8 @@ class System(Enum):
     GALACTIC = "GALACTIC"
     ECLIPTIC = "ECLIPTIC"
     TOPOCENTRIC = "TOPOCENTRIC"
+    # alt/az, stored latitude first (alt, az) unlike every other system
+    HORIZONTAL = "HORIZONTAL"
 
 
 class PositionOutsideLimitsError(Exception):
@@ -194,7 +196,7 @@ class Position:
                 f"Invalid ALT range {str(alt)}. Must be between 0-180 deg or -90 - +90 deg."
             )
 
-        return Position((alt, az), system=System.TOPOCENTRIC)
+        return Position((alt, az), system=System.HORIZONTAL)
 
     @staticmethod
     def from_long_lat(long, lat):
@@ -367,6 +369,19 @@ class Position:
     #
     # great circle distance
     #
+    @property
+    def _spherical(self):
+        """(longitude-like, latitude-like) in radians.
+
+        gcdist wants the pair in that order - it is written for (ra, dec) -
+        and every factory here stores it that way except from_alt_az, which
+        stores (alt, az): latitude first.
+        """
+        long_like, lat_like = self.radian
+        if self.system == System.HORIZONTAL:
+            return lat_like, long_like
+        return long_like, lat_like
+
     def angsep(self, other):
         """
         Calculate the Great Circle Distance from other.
@@ -376,8 +391,17 @@ class Position:
 
         @returns: The distance from this point to L{other}.
         @rtype: L{Coord} in degress (convertable, as this is a Coord).
+
+        @raises ValueError: when the two positions are in different
+        reference systems - the distance between an alt/az and an ra/dec
+        position is not a number, it is a mistake.
         """
-        return Coord.from_r(CoordUtil.gcdist(self.radian, other.radian)).to_d()
+        if self.system != other.system:
+            raise ValueError(
+                f"Cannot measure a distance between a {self.system} and a "
+                f"{other.system} position."
+            )
+        return Coord.from_r(CoordUtil.gcdist(self._spherical, other._spherical)).to_d()
 
     def within(self, other, eps=Coord.from_as(60)):
         """

--- a/tests/chimera/util/test_position.py
+++ b/tests/chimera/util/test_position.py
@@ -88,6 +88,40 @@ class TestPosition:
         assert p1.within(p2, Coord.from_d(29.99)) is False
         assert p1.within(p2, Coord.from_d(30.01)) is True
 
+    def test_distances_in_alt_az(self):
+        """from_alt_az stores (alt, az) - latitude first - while gcdist
+        reads its pair as (longitude, latitude). Passing the stored order
+        straight through called two points 2 degrees apart at the zenith
+        180 degrees apart."""
+        zenith_north = Position.from_alt_az(89, 0)
+        zenith_south = Position.from_alt_az(89, 180)
+        assert equal(float(zenith_north.angsep(zenith_south)), 2.0, 1e-6)
+
+        # a degree of altitude is a degree of separation, anywhere
+        assert equal(
+            float(Position.from_alt_az(80, 78).angsep(Position.from_alt_az(81, 78))),
+            1.0,
+            1e-6,
+        )
+
+        # a degree of azimuth is less than a degree of separation, by
+        # roughly cos(alt): 1.04143 deg from the spherical law of cosines
+        assert equal(
+            float(Position.from_alt_az(80, 78).angsep(Position.from_alt_az(80, 84))),
+            1.04143,
+            1e-5,
+        )
+
+        near_zenith = Position.from_alt_az(89, 0)
+        assert near_zenith.within(zenith_south, Coord.from_d(2.01)) is True
+        assert near_zenith.within(zenith_south, Coord.from_d(1.99)) is False
+
+    def test_distance_between_different_systems_is_refused(self):
+        with pytest.raises(ValueError):
+            Position.from_alt_az(45, 90).angsep(
+                Position.from_ra_dec("10:00:00", "0:0:0")
+            )
+
     def test_change_epoch(self):
         sirius_j2000 = Position.from_ra_dec("06 45 08.9173", "-16 42 58.017")
         sirius_now = sirius_j2000.to_epoch(epoch=Epoch.NOW)


### PR DESCRIPTION
Found reviewing chimera-skyflat, where a "am I already pointing at the flat
position, or must I slew?" check has to be written by hand today.

`angsep` passes `self.radian` to `CoordUtil.gcdist`, whose documented input
is `(ra, dec)` — longitude first, latitude second. Every factory stores the
pair that way **except `from_alt_az`**, which stores `(alt, az)`: latitude
first. The two roles are swapped, and nothing raises.

| positions (alt, az)      | true separation | `angsep` before |
|--------------------------|-----------------|-----------------|
| (89, 0) and (89, 180)    | 2°              | **180°**        |
| (80, 78) and (80.5, 78)  | 0.5°            | **0.10°**       |
| (80, 78) and (80, 84)    | 1.04°           | **6.00°**       |

So every alt/az proximity test written the obvious way is wrong. The sky
flat controller's `flat_position_max` check is one of them — it would have
slewed before every twilight frame, and the version of it that was in the
tree got commented out rather than debugged.

## The fix

- `from_alt_az` labels its positions `System.HORIZONTAL` rather than
  `System.TOPOCENTRIC`. `from_long_lat` keeps `TOPOCENTRIC` — it stores its
  pair the other way round, so one label could not describe both.
- `angsep` asks the position for its `(longitude, latitude)` pair instead of
  assuming the storage order.

## One behaviour change worth arguing about

`angsep` between two *different* systems now raises `ValueError`. The
distance between an alt/az position and an ra/dec one is not a quantity, and
quietly returning a number for it is how this bug survived. Nothing in-tree
does it — every caller compares ra/dec to ra/dec — but shout if you would
rather it kept returning garbage.

Out-of-tree code matching on `system == System.TOPOCENTRIC` for an alt/az
position would need updating; a grep across the plugin repos here found no
such caller.

## Testing

`tests/chimera/util/test_position.py::test_distances_in_alt_az` pins all
three rows above (values cross-checked against the spherical law of cosines,
not against this implementation) plus `within()` at the zenith, and
`test_distance_between_different_systems_is_refused` covers the raise. Full
suite green except `test_image.py::test_wcs`, which fails identically on
master.
