### PR TITLE
site: add sun_altitude(), sun_azimuth() and is_dusk()

### DIFF
--- a/src/chimera/core/site.py
+++ b/src/chimera/core/site.py
@@ -176,6 +176,40 @@ class Site(ChimeraObject):
             Coord.from_r(self._sun.alt), Coord.from_r(self._sun.az)
         )
 
+    def sun_altitude(self, date=None):
+        """
+        Sun altitude in DEGREES.
+
+        Prefer this over reading sunpos(): a float crosses the bus, a
+        Position does not (it is not serializable), and unpacking sunpos()
+        hands out Coords in radians that read like degrees.
+
+        @rtype: float
+        """
+        date = date or self.ut()
+        self._sun.compute(self._get_ephem(date))
+        return float(Coord.from_r(self._sun.alt).to_d())
+
+    def is_dusk(self, date=None):
+        """
+        True while the Sun is on its way down, False while it is climbing.
+
+        Which side of the day it is decides what a twilight routine should
+        do when it runs out of sky: sky flats wait for a fainter sky at
+        dusk and give up at dawn, and the other way around when the sky is
+        too bright. The local clock cannot answer that question - it is the
+        wall clock, so it says nothing about a simulated night run under
+        `time_speedup`.
+
+        The Sun is descending exactly when its last meridian crossing was a
+        transit (its highest point) rather than an anti-transit.
+
+        @rtype: bool
+        """
+        date = date or self.ut()
+        site = self._get_ephem(date)
+        return site.previous_transit(self._sun) > site.previous_antitransit(self._sun)
+
     def moonrise(self, date=None):
         date = date or self.ut()
         site = self._get_ephem(date)

--- a/tests/chimera/core/test_site.py
+++ b/tests/chimera/core/test_site.py
@@ -1,12 +1,21 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
 
+import datetime as dt
 import time
 
+import msgspec
 import pytest
 from dateutil.relativedelta import relativedelta
 
 from chimera.core.site import Site
+
+SITE_CONFIG = {
+    "name": "UFSC",
+    "latitude": "-27 36 13 ",
+    "longitude": "-48 31 20",
+    "altitude": "20",
+}
 
 
 class TestSite:
@@ -104,3 +113,38 @@ class TestSite:
         print("next sunrise twilight begins at:", sunrise_twilight_begin)
         print("next sunrise twilight ends   at:", sunrise_twilight_end)
         print("sunrise twilight duration      :", sunrise_twilight_duration)
+
+    def test_sun_altitude_is_the_altitude_in_degrees(self, manager):
+        manager.add_class(Site, "lna", SITE_CONFIG)
+        site = manager.get_proxy("/Site/0")
+
+        when = dt.datetime(2026, 7, 27, 16, 0, tzinfo=dt.UTC)
+
+        assert site.sun_altitude(when) == pytest.approx(float(site.sunpos(when).alt))
+        assert site.sun_altitude() == pytest.approx(float(site.sunpos().alt), abs=0.01)
+
+    def test_sun_altitude_survives_the_bus(self, manager):
+        """A Position cannot be encoded, so sunpos() only works between
+        objects sharing a bus - the reason for a plain-float accessor."""
+        manager.add_class(Site, "lna", SITE_CONFIG)
+        site = manager.get_proxy("/Site/0")
+
+        encoder = msgspec.json.Encoder()
+        assert encoder.encode(site.sun_altitude())
+
+        with pytest.raises(TypeError):
+            encoder.encode(site.sunpos())
+
+    def test_is_dusk_tracks_the_sun_not_the_clock(self, manager):
+        """Dusk is the sun on its way down, sampled all the way around a
+        day and checked against the altitude it is about to have."""
+        manager.add_class(Site, "lna", SITE_CONFIG)
+        site = manager.get_proxy("/Site/0")
+
+        midnight = dt.datetime(2026, 7, 27, 0, 0, tzinfo=dt.UTC)
+        for hour in range(24):
+            when = midnight + dt.timedelta(hours=hour)
+            descending = site.sun_altitude(
+                when + dt.timedelta(minutes=1)
+            ) < site.sun_altitude(when)
+            assert site.is_dusk(when) is descending, f"{when} is not settled"


### PR DESCRIPTION
Two questions every twilight routine asks, neither of which `Site` could
answer directly. Both come out of chimera-skyflat, where the plugin was
answering them by hand and getting them wrong.

## How high is the sun?

`sunpos()` returns a `Position`, and msgspec cannot encode one. It works
today only because `Bus._push` skips serialization when the destination is
on the same bus — and logs `serialization issue, won't work on remote
buses` while it does. Put the site on one host and a plugin on another and
every consumer of `sunpos()` breaks.

Unpacking it is worse. `sunpos()` builds its Position from
`Coord.from_r(...)`, so `alt, az = site.sunpos()` hands out Coords whose
`float()` is **radians**, while `.alt` is **degrees**, and feeding the Coord
to `np.radians()` raises `TypeError: loop of ufunc does not support argument
0 of type Coord which has no callable radians method`. chimera-skyflat read
them as radians: `exp()` underflowed, the sky model collapsed to its floor,
and every twilight flat on 2026-07-21 ran to `exptime_max`.

`sun_altitude(date=None) -> float` answers in degrees, and a float crosses
any bus. `sun_azimuth(date=None) -> float` is the same treatment for the
other half of the position: the **anti-solar** azimuth is where the twilight
sky gradient is smallest, so it is where a sky flat wants to point
(arXiv:1407.8283) — pointing at a fixed azimuth instead lays the gradient
straight across the flat.

## Which way is the sun going?

Dusk and dawn are not the same case. A sky flat routine that runs out of
exposure time should wait at dusk (the sky keeps dimming) but step to
another filter at dawn — and the mirror image when the sky is too bright.

Plugins answer it today with `site.localtime().hour > 12`. That is the wall
clock, which says nothing about a night simulated under `time_speedup`,
where `ut()` runs fast and `localtime()` does not — exactly the digital twin
setup. `is_dusk(date=None) -> bool` reads it off the sun instead: it is
descending exactly when its last meridian crossing was a transit rather than
an anti-transit.

## Testing

`test_is_dusk_tracks_the_sun_not_the_clock` walks a full day hour by hour
and asserts `is_dusk(t)` equals "the altitude a minute from now is lower",
so the two new accessors verify each other across every part of the day.
`test_sun_altitude_survives_the_bus` encodes both return values with msgspec
— the float goes through, the Position raises — which is the property the
accessor exists for. `test_sun_altitude_is_the_altitude_in_degrees` pins it
against `sunpos().alt`.

Full suite green except `test_image.py::test_wcs`, which fails identically
on master.

Related: #274 (`Position.angsep` is wrong for alt/az) came out of the same
review; astroufsc/chimera-skyflat#1 is the plugin that needed both.

