### PR TITLE
fix(util): restore flexible argument handling in Image WCS methods

### DIFF
--- a/src/chimera/util/image.py
+++ b/src/chimera/util/image.py
@@ -358,10 +358,17 @@ class Image(UserDict):
     # WCS
     #
     def pixel_at(self, *world):
+        """
+        World to pixel coordinates. Accepts either two scalars in decimal
+        degrees, a (ra, dec) tuple, or a Position.
+        """
         if not self._find_wcs():
             return (0, 0)
 
-        pixel = self._wcs.all_world2pix(np.array([[world[0], world[1]]]), 1)[0]
+        if len(world) == 1:
+            world = world[0].dd() if isinstance(world[0], Position) else tuple(world[0])
+
+        pixel = self._wcs.all_world2pix(np.array([world]), 1)[0]
 
         # round pixel to avoid large decimal numbers and get out strange -0
         pixel = list(round(p, 6) for p in pixel)
@@ -391,14 +398,21 @@ class Image(UserDict):
         return float(rot_deg)
 
     def world_at(self, *pixel):
+        """
+        Pixel to world coordinates. Accepts either two scalars or an
+        (x, y) tuple.
+        """
         if not self._find_wcs():
             return Position.from_ra_dec(0, 0)
 
-        world = self._wcs.all_pix2world(np.array([*pixel]), 1)[0]
+        if len(pixel) == 1:
+            pixel = tuple(pixel[0])
+
+        world = self._wcs.all_pix2world(np.array([pixel]), 1)[0]
         return Position.from_ra_dec(Coord.from_d(world[0]), Coord.from_d(world[1]))
 
     def world_at_center(self):
-        return self.pixel_at(self.center())
+        return self.world_at(self.center())
 
     def _find_wcs(self):
         if not self._wcs:


### PR DESCRIPTION
## Summary

CI was failing on `tests/chimera/util/test_image.py::TestImage::test_wcs` with:

```
ValueError: Wrong number of dimensions in input array.  Expected 2.
```

This is a regression from ae01ac8f, which dropped the `_value_at` helper that normalized the calling styles of the `Image` WCS conversion methods. The replacement code only handled the single-tuple style, so `world_at(0, 0)` built a 1-D `np.array([0, 0])`, which astropy's `all_pix2world` rejects.

## Changes

- `world_at()`: accept both two scalars and a single `(x, y)` tuple, normalizing to the 2-D `(1, 2)` array astropy expects.
- `pixel_at()`: same normalization, plus accept a `Position` via `.dd()` — `Position` has no `__getitem__`, so `pixel_at(position)` (exercised by the same test) raised `IndexError`.
- `world_at_center()`: call `world_at(self.center())` instead of `pixel_at(self.center())`, which passed pixel coordinates as world coordinates and returned pixels. No in-repo callers.

## Testing

- `uv run pytest tests/chimera/util/test_image.py` — 4 passed, 1 skipped (SExtractor binary not installed, pre-existing skip).
- Round-trip is exact: world at pixel (0,0) → 13:43:58.547 −88:02:37.388 → back to pixel (0.0, 0.0).
- ruff check / format clean.