### PR TITLE
ci: surface failures as GitHub annotations and job summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,19 +27,26 @@ jobs:
           enable-cache: true        
 
       - name: install
-        run: uv sync --locked --all-extras --dev        
+        run: uv sync --locked --all-extras --dev || { echo "::error title=uv sync failed::Dependency sync failed — likely uv.lock is out of date with pyproject.toml. Run 'uv lock' and commit."; exit 1; }
 
       - name: lint
-        run: uv run pre-commit run --all-files
+        run: uv run pre-commit run --all-files --show-diff-on-failure || { echo "::error title=lint failed::pre-commit checks failed — run 'uv run pre-commit run --all-files' locally."; exit 1; }
 
       - name: test
-        run: uv run pytest --cov-report=xml
+        run: uv run pytest --cov-report=xml --junitxml=junit.xml
+
+      - name: test summary
+        if: ${{ !cancelled() }}
+        uses: test-summary/action@v2
+        with:
+          paths: junit.xml
 
       - name: upload coverage to codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
         with:
           use_oidc: true
           files: coverage.xml
 
       - name: build
-        run: uv build
+        run: uv build || { echo "::error title=uv build failed::Package build failed — see the build step logs."; exit 1; }

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pip-log.txt
 .coverage
 coverage.xml
 htmlcov/
+junit.xml
 .tox
 nosetests.xml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     "pre-commit>=4.1.0",
     "pystack>=1.5.1; sys_platform == 'linux'",
     "pytest-cover>=3.0.0",
+    "pytest-github-actions-annotate-failures>=0.3.0",
     "pytest-memray>=1.8.0",
     "pytest-mock>=3.14.1",
     "pytest-timeout>=2.4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -210,6 +210,7 @@ dev = [
     { name = "pystack", marker = "sys_platform == 'linux'" },
     { name = "pytest" },
     { name = "pytest-cover" },
+    { name = "pytest-github-actions-annotate-failures" },
     { name = "pytest-memray" },
     { name = "pytest-mock" },
     { name = "pytest-timeout" },
@@ -240,6 +241,7 @@ dev = [
     { name = "pystack", marker = "sys_platform == 'linux'", specifier = ">=1.5.1" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cover", specifier = ">=3.0.0" },
+    { name = "pytest-github-actions-annotate-failures", specifier = ">=0.3.0" },
     { name = "pytest-memray", specifier = ">=1.8.0" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
@@ -832,6 +834,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/30/27/20964101a7cdb260f8d6c4e854659026968321d10c90552b1fe7f6c5f913/pytest-cover-3.0.0.tar.gz", hash = "sha256:5bdb6c1cc3dd75583bb7bc2c57f5e1034a1bfcb79d27c71aceb0b16af981dbf4", size = 3211, upload-time = "2015-08-01T19:20:22.562Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/9b/7b4700c462628e169bd859c6368d596a6aedc87936bde733bead9f875fce/pytest_cover-3.0.0-py2.py3-none-any.whl", hash = "sha256:578249955eb3b5f3991209df6e532bb770b647743b7392d3d97698dc02f39ebb", size = 3769, upload-time = "2015-08-01T19:20:18.534Z" },
+]
+
+[[package]]
+name = "pytest-github-actions-annotate-failures"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/a0/bdb91581b03c41016c78e16b8ec36c34d8508206fcb30f1951c9cdff2e97/pytest_github_actions_annotate_failures-0.4.2.tar.gz", hash = "sha256:5dd18304512361788bc7b5c5c805db853f03f4950c6be09b088de6bab8e2e6c9", size = 12158, upload-time = "2026-06-19T15:59:17.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/09/c44e658f3a27c588c2017d858c8b0fa962612af9b74326beabbf010c839c/pytest_github_actions_annotate_failures-0.4.2-py3-none-any.whl", hash = "sha256:02911cd3b55f235328a334f8ca6037a89944398b8e8b028c82de97111eff4071", size = 6151, upload-time = "2026-06-19T15:59:16.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

## Summary

When CI fails today, finding out *what* failed means digging through run logs. This surfaces failures directly on the PR. Every chimera PR comes from a fork, where the workflow token is read-only — so this deliberately uses only fork-safe mechanisms (log-parsed workflow commands and job summaries), no comment-posting actions.

- **Failing tests → inline annotations**: adds the pytest-dev-maintained [`pytest-github-actions-annotate-failures`](https://github.com/pytest-dev/pytest-github-actions-annotate-failures) plugin to the dev group. Each failing test annotates its file/line with the assertion message — shown in the Files changed tab (when the file is in the diff) and the Checks tab. Inert outside GitHub Actions.
- **Test summary table**: pytest now also writes `junit.xml`, and [`test-summary/action@v2`](https://github.com/test-summary/action) renders a pass/fail table into the job summary (`if: ${{ !cancelled() }}` so it runs precisely when tests fail).
- **Coverage upload on red runs**: the codecov step also gets `if: ${{ !cancelled() }}` — pytest-cov still writes `coverage.xml` when tests fail.
- **Clearer step failures**: `uv sync`, lint, and `uv build` failures now emit titled `::error` annotations with the likely cause (e.g. stale `uv.lock`); `pre-commit` runs with `--show-diff-on-failure` so ruff-format failures show the actual diff. ruff-check already annotates inline via the existing `RUFF_OUTPUT_FORMAT: github`.

## Test plan

- [x] Locally: `uv run pytest --junitxml=junit.xml -k url` → 16 passed, `junit.xml` produced, no annotation output
- [x] With `GITHUB_ACTIONS=true` and a deliberately failing test: plugin emits `::error file=…,line=…::…AssertionError…`
- [ ] CI run on this PR is green (annotations only fire on failure)
