### PR TITLE
fix(scheduler): abort the in-flight program cleanly on shutdown

### DIFF
--- a/src/chimera/controllers/scheduler/controller.py
+++ b/src/chimera/controllers/scheduler/controller.py
@@ -85,7 +85,19 @@ class Scheduler(ChimeraObject):
 
     def __stop__(self):
         self.log.debug("Attempting to stop machine")
-        self.shutdown()
+        self.shutdown()  # machine.state(SHUTDOWN); wakes any sleep
+        machine = self.machine
+        if machine is not None and machine.ident is not None:
+            # the machine runs executor.stop() on its way out: this join
+            # covers the abort round-trip (abort_exposure waits the readout)
+            machine.join(timeout=10)
+            if machine.is_alive():
+                self.log.warning("scheduler machine did not stop in 10s")
+            worker = machine.current_worker
+            if worker is not None and worker.is_alive():
+                worker.join(timeout=10)
+                if worker.is_alive():
+                    self.log.warning("scheduler program worker did not stop in 10s")
         self.log.debug("Machine stopped")
         Session().commit()
         return True

--- a/src/chimera/controllers/scheduler/executor.py
+++ b/src/chimera/controllers/scheduler/executor.py
@@ -51,8 +51,7 @@ class ProgramExecutor:
             self._inject_instrument(handler)
 
     def execute(self, program):
-        self.must_stop.clear()
-
+        # must_stop is armed by Machine._process before this thread starts
         for action in program.actions:
             # aborted?
             if self.must_stop.is_set():
@@ -87,9 +86,16 @@ class ProgramExecutor:
                 log.debug("[finish] took: %f s" % (time.time() - t0))
 
     def stop(self):
+        # always arm: a worker that has not reached its first action yet must
+        # still see the abort at its next checkpoint
+        self.must_stop.set()
         if self.current_handler:
-            self.must_stop.set()
-            self.current_handler.abort(self.current_action)
+            try:
+                self.current_handler.abort(self.current_action)
+            except Exception:
+                # abort is a bus round-trip; if the bus is already gone the
+                # machine must still exit cleanly
+                log.exception("error aborting current action")
 
     def _inject_instrument(self, handler):
         if not issubclass(handler, ActionHandler):

--- a/src/chimera/controllers/scheduler/handlers.py
+++ b/src/chimera/controllers/scheduler/handlers.py
@@ -1,5 +1,10 @@
 from chimera.controllers.imageserver.imagerequest import ImageRequest
-from chimera.core.exceptions import ProgramExecutionException, print_exception
+from chimera.core.exceptions import (
+    BusDeadException,
+    ObjectNotFoundException,
+    ProgramExecutionException,
+    print_exception,
+)
 from chimera.util.position import Epoch
 
 
@@ -84,6 +89,9 @@ class PointHandler(ActionHandler):
             if action.pa is not None:
                 rotator.move_to(action.pa)
 
+        except (BusDeadException, ObjectNotFoundException):
+            # shutdown/bus loss is an abort condition, not a program error
+            raise
         except Exception as e:
             raise ProgramExecutionException(str(e))
 
@@ -171,6 +179,9 @@ class ExposeHandler(ActionHandler):
 
         try:
             camera.expose(ir)
+        except (BusDeadException, ObjectNotFoundException):
+            # shutdown/bus loss is an abort condition, not a program error
+            raise
         except Exception as e:
             print_exception(e)
             raise ProgramExecutionException("Error while exposing")
@@ -200,6 +211,9 @@ class AutoFocusHandler(ActionHandler):
                 step=action.step,
                 filter=action.filter,
             )
+        except (BusDeadException, ObjectNotFoundException):
+            # shutdown/bus loss is an abort condition, not a program error
+            raise
         except Exception as e:
             print_exception(e)
             raise ProgramExecutionException("Error while autofocusing")
@@ -222,6 +236,9 @@ class AutoFlatHandler(ActionHandler):
 
         try:
             autoflat.get_flats(action.filter, n_flats=action.frames, request=request)
+        except (BusDeadException, ObjectNotFoundException):
+            # shutdown/bus loss is an abort condition, not a program error
+            raise
         except Exception as e:
             print_exception(e)
             raise ProgramExecutionException("Error trying to take flats")
@@ -244,6 +261,9 @@ class AutoguideHandler(ActionHandler):
                 )
             else:
                 autoguider.stop_guiding()
+        except (BusDeadException, ObjectNotFoundException):
+            # shutdown/bus loss is an abort condition, not a program error
+            raise
         except Exception as e:
             print_exception(e)
             raise ProgramExecutionException("Error while autoguiding")
@@ -265,6 +285,9 @@ class PointVerifyHandler(ActionHandler):
                 pv.point_verify()
             elif action.choose is not None:
                 pv.choose()
+        except (BusDeadException, ObjectNotFoundException):
+            # shutdown/bus loss is an abort condition, not a program error
+            raise
         except Exception as e:
             raise ProgramExecutionException(str(e))
 
@@ -281,6 +304,9 @@ class OperatorHandler(ActionHandler):
 
         try:
             op.request(action.type, action.message)
+        except (BusDeadException, ObjectNotFoundException):
+            # shutdown/bus loss is an abort condition, not a program error
+            raise
         except Exception as e:
             raise ProgramExecutionException(str(e))
 

--- a/src/chimera/controllers/scheduler/machine.py
+++ b/src/chimera/controllers/scheduler/machine.py
@@ -4,7 +4,12 @@ import threading
 from chimera.controllers.scheduler.model import Program, Session
 from chimera.controllers.scheduler.states import State
 from chimera.controllers.scheduler.status import SchedulerStatus
-from chimera.core.exceptions import ProgramExecutionAborted, ProgramExecutionException
+from chimera.core.exceptions import (
+    BusDeadException,
+    ObjectNotFoundException,
+    ProgramExecutionAborted,
+    ProgramExecutionException,
+)
 
 log = logging.getLogger(__name__)
 
@@ -22,8 +27,11 @@ class Machine(threading.Thread):
         self.controller = controller
 
         self.current_program = None
+        self.current_worker = None
 
-        self.daemon = False
+        # a hung instrument must not block interpreter exit: the graceful
+        # path joins this thread explicitly (Scheduler.__stop__)
+        self.daemon = True
 
     def state(self, state=None):
         self.__state_lock.acquire()
@@ -31,6 +39,11 @@ class Machine(threading.Thread):
             if not state:
                 return self.__state
             if state == self.__state:
+                return
+            if self.__state == State.SHUTDOWN:
+                # terminal: a finishing worker must not resurrect the machine
+                # by setting IDLE/OFF concurrently with shutdown
+                log.debug(f"Ignoring change to {state}: machine is shutting down.")
                 return
             self.controller.state_changed(state, self.__state)
             log.debug(f"Changing state, from {self.__state} to {state}.")
@@ -46,17 +59,28 @@ class Machine(threading.Thread):
         # inject instruments on handlers
         self.executor.__start__()
 
-        while self.state() != State.SHUTDOWN:
-            if self.state() == State.OFF:
-                log.debug("[off] will just sleep..")
-                self.sleep()
+        # one state snapshot per iteration: SHUTDOWN is checked first, so a
+        # shutdown requested while BUSY still runs executor.stop() (the old
+        # while-condition exited the loop right past that branch)
+        while True:
+            state = self.state()
 
-            if self.state() == State.START:
+            if state == State.SHUTDOWN:
+                log.debug("[shutdown] trying to stop current program")
+                self.executor.stop()
+                log.debug("[shutdown] should die soon.")
+                break
+
+            if state == State.OFF:
+                log.debug("[off] will just sleep..")
+                self.sleep(until_leaves=State.OFF)
+
+            elif state == State.START:
                 log.debug("[start] database changed, rescheduling...")
                 self.scheduler.reschedule(self)
                 self.state(State.IDLE)
 
-            if self.state() == State.IDLE:
+            elif state == State.IDLE:
                 log.debug("[idle] looking for something to do...")
 
                 # find something to do
@@ -75,28 +99,26 @@ class Machine(threading.Thread):
                 self.current_program = None
                 self.state(State.OFF)
 
-            elif self.state() == State.BUSY:
+            elif state == State.BUSY:
                 log.debug("[busy] waiting tasks to finish..")
-                self.sleep()
+                self.sleep(until_leaves=State.BUSY)
 
-            elif self.state() == State.STOP:
+            elif state == State.STOP:
                 log.debug("[stop] trying to stop current program")
                 self.executor.stop()
                 self.state(State.OFF)
 
-            elif self.state() == State.SHUTDOWN:
-                log.debug("[shutdown] trying to stop current program")
-                self.executor.stop()
-                log.debug("[shutdown] should die soon.")
-                break
-
         log.debug("[shutdown] thread ending...")
 
-    def sleep(self):
-        self.__wake_up_call.acquire()
-        log.debug("Sleeping")
-        self.__wake_up_call.wait()
-        self.__wake_up_call.release()
+    def sleep(self, until_leaves=None):
+        with self.__wake_up_call:
+            log.debug("Sleeping")
+            if until_leaves is None:
+                self.__wake_up_call.wait()
+            else:
+                # re-check under the condition lock: a state change notified
+                # between our caller's snapshot and this wait must not be lost
+                self.__wake_up_call.wait_for(lambda: self.__state != until_leaves)
 
     def wake_up(self):
         self.__wake_up_call.acquire()
@@ -122,55 +144,61 @@ class Machine(threading.Thread):
 
             log.debug(f"[start] {str(task)}")
 
-            # the manager-injected site, not a private Site(): one clock
-            # system-wide
-            site = self.controller.get_site()
-            now_mjd = site.mjd()
-            log.debug("[start] Current MJD is %f", now_mjd)
-            if program.start_at:
-                wait_time = (program.start_at - now_mjd) * 86.4e3
-                if wait_time > 0.0:
-                    log.debug(
-                        "[start] Waiting until MJD %f to start slewing",
-                        program.start_at,
-                    )
-                    log.debug("[start] Will wait %f s (site time)", wait_time)
-                    # Poll the site clock so a fast-forwarded site compresses
-                    # the wait for free (no speedup knowledge here), and block
-                    # on the machine's wake-up Condition -- notified on every
-                    # state change -- so a STOP/SHUTDOWN breaks the wait at once
-                    # instead of after a fixed sleep.
-                    while site.mjd() < program.start_at:
-                        if self.state() in (State.STOP, State.SHUTDOWN):
-                            log.debug("[start] Aborted while waiting for slew start")
-                            return
-                        with self.__wake_up_call:
-                            self.__wake_up_call.wait(1.0)
-                else:
-                    if program.valid_for >= 0.0:
-                        if -wait_time > program.valid_for:
-                            log.debug(
-                                "[start] Program is not valid anymore {program.start_at}, {program.valid_for}"
-                            )
-                            self.controller.program_complete(
-                                program.id,
-                                SchedulerStatus.OK,
-                                "Program not valid anymore.",
-                            )
-                    else:
+            # the events and instrument calls below talk to the bus: keep
+            # everything under one try so a dying bus can never kill this
+            # thread unhandled
+            try:
+                # the manager-injected site, not a private Site(): one clock
+                # system-wide
+                site = self.controller.get_site()
+                now_mjd = site.mjd()
+                log.debug("[start] Current MJD is %f", now_mjd)
+                if program.start_at:
+                    wait_time = (program.start_at - now_mjd) * 86.4e3
+                    if wait_time > 0.0:
                         log.debug(
-                            "[start] Specified slew start MJD %s has already passed; proceeding without waiting",
+                            "[start] Waiting until MJD %f to start slewing",
                             program.start_at,
                         )
-            else:
-                log.debug("[start] No slew time specified, so no waiting")
-            log.debug("[start] Current MJD is %f", site.mjd())
-            log.debug(
-                "[start] Proceeding since MJD %f should have passed", program.start_at
-            )
-            self.controller.program_begin(program.id)
+                        log.debug("[start] Will wait %f s (site time)", wait_time)
+                        # Poll the site clock so a fast-forwarded site compresses
+                        # the wait for free (no speedup knowledge here), and block
+                        # on the machine's wake-up Condition -- notified on every
+                        # state change -- so a STOP/SHUTDOWN breaks the wait at once
+                        # instead of after a fixed sleep.
+                        while site.mjd() < program.start_at:
+                            if self.state() in (State.STOP, State.SHUTDOWN):
+                                log.debug(
+                                    "[start] Aborted while waiting for slew start"
+                                )
+                                return
+                            with self.__wake_up_call:
+                                self.__wake_up_call.wait(1.0)
+                    else:
+                        if program.valid_for >= 0.0:
+                            if -wait_time > program.valid_for:
+                                log.debug(
+                                    "[start] Program is not valid anymore {program.start_at}, {program.valid_for}"
+                                )
+                                self.controller.program_complete(
+                                    program.id,
+                                    SchedulerStatus.OK,
+                                    "Program not valid anymore.",
+                                )
+                        else:
+                            log.debug(
+                                "[start] Specified slew start MJD %s has already passed; proceeding without waiting",
+                                program.start_at,
+                            )
+                else:
+                    log.debug("[start] No slew time specified, so no waiting")
+                log.debug("[start] Current MJD is %f", site.mjd())
+                log.debug(
+                    "[start] Proceeding since MJD %f should have passed",
+                    program.start_at,
+                )
+                self.controller.program_begin(program.id)
 
-            try:
                 self.executor.execute(task)
                 log.debug(f"[finish] {str(task)}")
                 self.scheduler.done(task)
@@ -190,9 +218,42 @@ class Machine(threading.Thread):
                 )
                 self.state(State.OFF)
                 log.debug(f"[aborted by user] {str(task)}")
+            except BusDeadException as e:
+                # the bus died: record an abort, never march on to the
+                # next program
+                log.warning(f"[aborted] {str(task)}: bus is dead ({e})")
+                self.scheduler.done(task, error=e)
+                self.controller.program_complete(
+                    program.id, SchedulerStatus.ABORTED, "System shutdown."
+                )
+                self.state(State.OFF)  # ignored when already shutting down
+            except ObjectNotFoundException as e:
+                if self.state() in (State.STOP, State.SHUTDOWN):
+                    # proxies vanish while the system tears down: an abort,
+                    # not a program failure
+                    log.warning(f"[aborted] {str(task)}: {e}")
+                    self.scheduler.done(task, error=e)
+                    self.controller.program_complete(
+                        program.id, SchedulerStatus.ABORTED, "System shutdown."
+                    )
+                    self.state(State.OFF)
+                else:
+                    # the program needs an object that is not deployed: fail
+                    # this program, keep the schedule going
+                    log.warning(f"[error] {str(task)}: {e}")
+                    self.scheduler.done(task, error=e)
+                    self.controller.program_complete(
+                        program.id, SchedulerStatus.ERROR, str(e)
+                    )
+                    self.state(State.IDLE)
+            finally:
+                session.commit()
 
-            session.commit()
+        # arm here, not in execute(): stop() runs on this same (machine)
+        # thread, so an abort can never race the worker to the flag
+        self.executor.must_stop.clear()
 
-        t = threading.Thread(target=process)
-        t.daemon = False
+        t = threading.Thread(target=process, name=f"scheduler-program-{program.id}")
+        t.daemon = True
+        self.current_worker = t
         t.start()

--- a/tests/chimera/controllers/test_scheduler_machine.py
+++ b/tests/chimera/controllers/test_scheduler_machine.py
@@ -1,0 +1,249 @@
+import threading
+import time
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+import chimera.controllers.scheduler.machine as machine_module
+from chimera.controllers.scheduler.executor import ProgramExecutor
+from chimera.controllers.scheduler.handlers import ExposeHandler
+from chimera.controllers.scheduler.machine import Machine
+from chimera.controllers.scheduler.states import State
+from chimera.controllers.scheduler.status import SchedulerStatus
+from chimera.core.exceptions import (
+    BusDeadException,
+    ObjectNotFoundException,
+    ProgramExecutionAborted,
+    ProgramExecutionException,
+)
+
+
+class FakeProgram:
+    def __init__(self, program_id=1):
+        self.id = program_id
+        self.start_at = 0.0
+        self.valid_for = -1
+
+    def __str__(self):
+        return f"#{self.id} fake program"
+
+
+class FakeScheduler:
+    def __init__(self, programs):
+        self._programs = list(programs)
+        self.done_calls = []
+
+    def reschedule(self, machine):
+        pass
+
+    def __next__(self):
+        return self._programs.pop(0) if self._programs else None
+
+    def done(self, task, error=None):
+        self.done_calls.append((task, error))
+
+
+class FakeExecutor:
+    """Blocks in execute() until an abort arrives, like a long exposure."""
+
+    def __init__(self):
+        self.must_stop = threading.Event()
+        self.execute_entered = threading.Event()
+        self.stop_calls = 0
+
+    def __start__(self):
+        pass
+
+    def execute(self, task):
+        self.execute_entered.set()
+        if not self.must_stop.wait(5):
+            raise AssertionError("abort never arrived")
+        raise ProgramExecutionAborted()
+
+    def stop(self):
+        self.stop_calls += 1
+        self.must_stop.set()
+
+
+def _wait_for_state(machine, state, timeout=5):
+    deadline = time.monotonic() + timeout
+    while machine.state() != state and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert machine.state() == state, f"machine never reached {state}"
+
+
+@pytest.fixture
+def no_db(monkeypatch):
+    # the worker opens a model Session only to merge/commit the program;
+    # the machine logic under test never needs the real sqlite file
+    session = MagicMock()
+    session.merge.side_effect = lambda program: program
+    monkeypatch.setattr(machine_module, "Session", MagicMock(return_value=session))
+
+
+def test_shutdown_while_busy_runs_executor_stop(no_db):
+    # regression: SHUTDOWN set while the machine slept in BUSY used to exit
+    # the run loop without ever calling executor.stop()
+    program = FakeProgram()
+    scheduler = FakeScheduler([program])
+    executor = FakeExecutor()
+    controller = MagicMock()
+    controller.get_site.return_value.mjd.return_value = 0.0
+
+    machine = Machine(scheduler, executor, controller)
+    machine.start()
+    _wait_for_state(machine, State.OFF)  # run() sets OFF on entry
+    machine.state(State.START)  # what Scheduler.start() does
+    try:
+        assert executor.execute_entered.wait(5), "worker never reached execute()"
+        assert machine.state() == State.BUSY
+
+        # what Scheduler.__stop__ does
+        machine.state(State.SHUTDOWN)
+        machine.join(5)
+        assert not machine.is_alive(), "machine thread did not exit on SHUTDOWN"
+        assert executor.stop_calls == 1
+
+        worker = machine.current_worker
+        worker.join(5)
+        assert not worker.is_alive(), "program worker did not finish"
+
+        statuses = [c.args[1] for c in controller.program_complete.call_args_list]
+        assert statuses == [SchedulerStatus.ABORTED]
+        assert isinstance(scheduler.done_calls[0][1], ProgramExecutionAborted)
+    finally:
+        machine.state(State.SHUTDOWN)
+        machine.join(5)
+
+
+def test_shutdown_state_is_sticky():
+    controller = MagicMock()
+    machine = Machine(FakeScheduler([]), FakeExecutor(), controller)
+
+    machine.state(State.SHUTDOWN)
+    assert controller.state_changed.call_count == 1
+
+    machine.state(State.IDLE)
+    machine.state(State.OFF)
+
+    assert machine.state() == State.SHUTDOWN
+    assert controller.state_changed.call_count == 1
+
+
+def test_missing_object_is_program_error(no_db, monkeypatch):
+    # a program that needs an undeployed object (e.g. an autofocus action
+    # with no Autofocus controller) must not kill the worker thread:
+    # outside shutdown it is a program ERROR and the schedule keeps going
+    caught = []
+    monkeypatch.setattr(threading, "excepthook", lambda args: caught.append(args))
+
+    program = FakeProgram()
+    scheduler = FakeScheduler([program])
+    executor = FakeExecutor()
+    executor.execute = MagicMock(
+        side_effect=ObjectNotFoundException("no /Autofocus/0")
+    )
+    controller = MagicMock()
+    controller.get_site.return_value.mjd.return_value = 0.0
+
+    machine = Machine(scheduler, executor, controller)
+    machine.start()
+    _wait_for_state(machine, State.OFF)  # run() sets OFF on entry
+    machine.state(State.START)  # what Scheduler.start() does
+    try:
+        deadline = time.monotonic() + 5
+        while not scheduler.done_calls and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert scheduler.done_calls, "worker never reported done()"
+        assert isinstance(scheduler.done_calls[0][1], ObjectNotFoundException)
+
+        machine.current_worker.join(5)
+        statuses = [c.args[1] for c in controller.program_complete.call_args_list]
+        assert statuses == [SchedulerStatus.ERROR]
+        # the machine went back to look for the next program (queue is empty)
+        _wait_for_state(machine, State.OFF)
+        assert not caught, f"worker thread died unhandled: {caught}"
+    finally:
+        machine.state(State.SHUTDOWN)
+        machine.join(5)
+
+
+def test_worker_aborts_on_dead_bus(no_db):
+    # a dead bus must abort the current program and stop the schedule: the
+    # old code recorded a generic error and marched on to the next program
+    programs = [FakeProgram(1), FakeProgram(2)]
+    scheduler = FakeScheduler(programs)
+    executor = FakeExecutor()
+    executor.execute = MagicMock(side_effect=BusDeadException("bus died"))
+    controller = MagicMock()
+    controller.get_site.return_value.mjd.return_value = 0.0
+
+    machine = Machine(scheduler, executor, controller)
+    machine.start()
+    _wait_for_state(machine, State.OFF)  # run() sets OFF on entry
+    machine.state(State.START)  # what Scheduler.start() does
+    try:
+        deadline = time.monotonic() + 5
+        while not scheduler.done_calls and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert scheduler.done_calls, "worker never reported done()"
+        assert isinstance(scheduler.done_calls[0][1], BusDeadException)
+
+        machine.current_worker.join(5)
+        _wait_for_state(machine, State.OFF)
+        statuses = [c.args[1] for c in controller.program_complete.call_args_list]
+        assert statuses == [SchedulerStatus.ABORTED]
+        assert executor.execute.call_count == 1, "second program ran on a dead bus"
+    finally:
+        machine.state(State.SHUTDOWN)
+        machine.join(5)
+
+
+def test_executor_stop_arms_without_handler():
+    executor = ProgramExecutor(MagicMock())
+    assert executor.current_handler is None
+
+    executor.stop()
+
+    assert executor.must_stop.is_set()
+
+
+def _expose_action():
+    return types.SimpleNamespace(
+        filter=None,
+        frames=1,
+        exptime=1.0,
+        shutter="OPEN",
+        image_type="OBJECT",
+        filename="test",
+        object_name="obj",
+        window=None,
+        binning=None,
+        wait_dome=False,
+        compress_format="NO",
+        program=types.SimpleNamespace(name="PRG", pi="pi"),
+    )
+
+
+@pytest.fixture
+def expose_instruments():
+    ExposeHandler.camera = MagicMock()
+    ExposeHandler.filterwheel = MagicMock()
+    yield ExposeHandler.camera
+    del ExposeHandler.camera
+    del ExposeHandler.filterwheel
+
+
+def test_expose_handler_reraises_bus_death(expose_instruments):
+    expose_instruments.expose.side_effect = BusDeadException("bus died")
+
+    with pytest.raises(BusDeadException):
+        ExposeHandler.process(_expose_action())
+
+
+def test_expose_handler_wraps_ordinary_errors(expose_instruments):
+    expose_instruments.expose.side_effect = RuntimeError("boom")
+
+    with pytest.raises(ProgramExecutionException):
+        ExposeHandler.process(_expose_action())


### PR DESCRIPTION
Second of two stacked PRs fixing the Ctrl+C shutdown cascade. **Stacked on
#280** — the first commit here *is* that PR; review only the last commit
(`fix(scheduler): abort the in-flight program cleanly on shutdown`). I'll
rebase this branch once #280 lands, which will drop the shared commit.

## Problem

With #280 in place the bus stays alive through shutdown, but the scheduler
still mishandled it: the running exposure was never aborted, the program was
recorded as an ordinary error, and the machine marched on to start the *next*
program mid-teardown. Four independent bugs:

- the machine's run-loop condition skipped the SHUTDOWN branch when the state
  changed while it slept in BUSY, so `executor.stop()` never ran; the loop now
  takes one state snapshot per iteration with SHUTDOWN checked first
- a finishing worker could overwrite SHUTDOWN with IDLE/OFF and resurrect the
  machine; SHUTDOWN is now sticky
- the worker's preamble (site clock, slew-start wait, `program_begin`) ran
  outside any exception handler, so a dying proxy killed the thread unhandled;
  the whole body now sits under one try
- `Scheduler.__stop__` joined nothing; it now joins the machine and the program
  worker (10s each, warns on timeout) so the abort round-trip completes before
  instruments stop

Plus supporting changes: handlers re-raise `BusDeadException` /
`ObjectNotFoundException` instead of wrapping them as program errors;
`executor.stop()` always arms `must_stop` and survives a failing abort
round-trip; the arm/clear moved to the machine thread so an abort can never
race the worker to the flag; `Machine.sleep()` re-checks state under the
condition lock, closing a missed-wakeup race.

Exception semantics: `BusDeadException` always aborts the program and stops
the schedule. `ObjectNotFoundException` aborts only during STOP/SHUTDOWN —
otherwise it stays a program ERROR and the schedule continues, so a schedule
referencing an undeployed controller (e.g. sample-sched.yaml's autofocus /
autoguide actions) behaves exactly as before.

Interrupted programs keep `finished=False` and re-run from their first action
on the next start — no DB/schema changes.

## Verification

- 7 new tests in `tests/chimera/controllers/test_scheduler_machine.py`,
  including regressions for the skipped-SHUTDOWN-branch bug and the
  next-program-on-dead-bus march; full suite green locally (270 passed,
  9 skipped)
- E2E on a live system: SIGINT mid-exposure → exposure aborted in ~2.5s,
  program marked ABORTED, instruments stopped in order, bus last, exit 0 with
  zero tracebacks; SIGINT while idle → exit 0; double SIGINT → forced exit 130

## Notes for reviewers (out of scope here)

- `sample-sched.yaml` PRG01 has autofocus/pointverify/autoguide actions whose
  controllers aren't in the default config → those actions fail as program
  ERRORs (pre-existing behavior, preserved)
- `sequential.done()` logs every error with a full traceback, so even a clean
  abort prints a `ProgramExecutionAborted` stack — cosmetic, could be toned
  down later
- the 10s join timeouts in `Scheduler.__stop__` may want to be configurable
  for slow-readout cameras