### PR TITLE
fix(cli): shut down in order on ctrl-c, keeping the bus alive throughout

### DIFF
--- a/src/chimera/cli/chimera.py
+++ b/src/chimera/cli/chimera.py
@@ -9,6 +9,7 @@ import os.path
 import platform
 import signal
 import sys
+import threading
 from typing import Any
 
 import chimera.core.log
@@ -28,6 +29,9 @@ log = logging.getLogger(__name__)
 class ChimeraCLI:
     def __init__(self):
         self.options = self.parse_args()
+
+        self._shutdown_requested = threading.Event()
+        self._shutdown_done = False
 
         try:
             self.config = ChimeraConfig.from_file(self.options.config_file)
@@ -135,6 +139,12 @@ class ChimeraCLI:
             )
             sys.exit(1)
 
+        # ctrl-c must not break the selector loop: responses from remote buses
+        # arrive on the socket only that loop reads, so the shutdown RPCs need
+        # it alive. The handler spawns the orderly shutdown off-thread and
+        # select() simply resumes (PEP 475); a second ctrl-c force-quits.
+        signal.signal(signal.SIGINT, self._on_sigint)
+
         log.info(f"Chimera: running on {self.options.host}:{self.options.port}")
 
         # init from config
@@ -151,9 +161,8 @@ class ChimeraCLI:
         log.info("System up and running.")
 
         try:
+            # returns when the shutdown thread calls bus.shutdown()
             self.bus.run_forever()
-        except KeyboardInterrupt:
-            log.info("Caught Ctrl-C, shutting down...")
         finally:
             self.shutdown()
 
@@ -168,10 +177,29 @@ class ChimeraCLI:
         except Exception:
             log.exception(f"error starting {location.path}")
 
+    def _on_sigint(self, signum, frame):
+        # no logging in a signal handler: the interrupted thread may hold the
+        # logging lock
+        if self._shutdown_requested.is_set():
+            os.write(2, b"ctrl-c again: forcing exit\n")
+            os._exit(130)
+        self._shutdown_requested.set()
+        threading.Thread(
+            target=self.shutdown, name="chimera-shutdown", daemon=True
+        ).start()
+
     def shutdown(self):
+        # entered by the sigint thread and by run()'s finally: first one wins
+        if self._shutdown_done:
+            return
+        self._shutdown_done = True
         log.info("Shutting down system.")
-        self.bus.shutdown()
+        # stop objects first, while the bus still routes: the scheduler aborts
+        # its running program over live RPC, instruments stop cleanly
         self.manager.shutdown()
+        # the bus goes down last: this wakes the selector and run_forever returns
+        self.bus.shutdown()
+        log.info("System shut down.")
 
 
 def main():


### PR DESCRIPTION
First of two stacked PRs fixing the Ctrl+C shutdown cascade. This one fixes the
root cause in the CLI; the scheduler-side fixes that make the in-flight program
abort cleanly are stacked on top in #279.

## Problem

Ctrl+C on a running `chimera` produced a cascade of tracebacks: in-flight RPCs
died with `BusDeadException`, instrument control loops crashed resolving
proxies, and `manager.shutdown()` only ran after everything had already burned
down.

Root cause: the bus selector loop runs on the main thread, so SIGINT became a
`KeyboardInterrupt` inside `selector.select()` that unwound through `_run`'s
`finally` and ran `_teardown()` **mid-unwind** — the bus was dead and every
mailbox closed before any orderly shutdown could begin. On top of that,
`ChimeraCLI.shutdown()` stopped the bus *before* the manager, so even the
orderly path ran object teardown against a dead bus.

## Design

Never let SIGINT break the selector loop. The CLI installs a handler that never
raises: it spawns a daemon shutdown thread and `select()` simply resumes
(PEP 475). The bus keeps routing — local *and* remote (remote responses arrive
on the socket only the selector loop reads, and proxies default to no timeout,
so shutdown RPCs need it alive) — while the manager stops objects newest-first.
Only then does `bus.shutdown()` run, through its normal tested path: the waker
fd wakes the selector, the loop thread runs `_teardown()`, and `run_forever()`
returns. A second Ctrl+C force-exits with status 130.

**Zero changes to bus.py**; both existing bus-shutdown tests are untouched
(`test_bus_graceful_shutdown` already covers exactly the path Ctrl+C now
takes).

## Verification

- full suite green locally
- E2E on a live system (with #279 stacked on top): SIGINT mid-exposure →
  instruments stopped in order, bus last, exit 0 with zero tracebacks; SIGINT
  while idle → exit 0; double SIGINT → forced exit 130