### PR TITLE
Automatic pier flip in TelescopeBase (replaces chimera-autopierchange)

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -83,6 +83,30 @@ cannot reach position surfaces as an error instead of silently unfocused data.
 This replaces the ``chimera-filterfocus`` plugin, whose ``focus_filters`` and ``focus_difference``
 options map to the ``focus_offsets`` mapping above.
 
+Automatic pier flip
+^^^^^^^^^^^^^^^^^^^
+
+::
+
+    telescope:
+        name: fake
+        type: FakeTelescope
+        pier_flip_ha: 0
+
+A German equatorial mount cannot track indefinitely past the meridian: sooner or later the tube
+runs into the pier. Set *pier_flip_ha* to the hour angle, in hours, where that becomes a problem
+and the telescope re-slews to the position it is already pointing at as soon as tracking takes it
+there, which is what makes the mount pick the other side of the pier. ``0`` flips at the meridian,
+``0.5`` gives it another 30 minutes of tracking.
+
+Only a mount that arrived at the limit *by tracking* is flipped; slewing straight to an object
+that is already past it leaves the mount on whichever side its own driver chose. The flip fires
+``slew_begin``/``slew_complete`` like any other slew, so a dome in ``track`` mode follows along.
+
+Leave ``pier_flip_ha`` unset (the default) on a fork or alt-azimuth mount, which has nothing to
+flip. This replaces the ``chimera-autopierchange`` plugin, whose ``ha_flip`` option maps to
+``pier_flip_ha``.
+
 Controllers Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/chimera/cli/tel.py
+++ b/src/chimera/cli/tel.py
@@ -381,6 +381,14 @@ class ChimeraTel(ChimeraCLI):
                 "current side of pier: %s "
                 % telescope.get_pier_side().__str__().lower()
             )
+        self.out(
+            "automatic pier flip: %s"
+            % (
+                f"at hour angle {telescope['pier_flip_ha']} h"
+                if telescope["pier_flip_ha"] is not None
+                else "disabled"
+            )
+        )
 
         if self.telescope["fans"] is not None:
             for fan in self.telescope["fans"]:

--- a/src/chimera/core/site.py
+++ b/src/chimera/core/site.py
@@ -265,12 +265,13 @@ class Site(ChimeraObject):
 
     def ra_to_ha(self, ra: float):
         # ra in hours
-        # returns ha in hours
-        return float(
+        # returns ha in hours, in [-12, +12): east of the meridian is negative
+        ha = float(
             CoordUtil.ra_to_ha(
                 Coord.from_h(ra), Coord.from_r(self.lst_in_rads())
             ).to_h()
         )
+        return (ha + 12) % 24 - 12
 
     def ha_to_ra(self, ha: float):
         return float(

--- a/src/chimera/core/site.py
+++ b/src/chimera/core/site.py
@@ -265,13 +265,12 @@ class Site(ChimeraObject):
 
     def ra_to_ha(self, ra: float):
         # ra in hours
-        # returns ha in hours, in [-12, +12): east of the meridian is negative
-        ha = float(
+        # returns ha in hours, +/-12: east of the meridian is negative
+        return float(
             CoordUtil.ra_to_ha(
                 Coord.from_h(ra), Coord.from_r(self.lst_in_rads())
             ).to_h()
         )
-        return (ha + 12) % 24 - 12
 
     def ha_to_ra(self, ha: float):
         return float(

--- a/src/chimera/instruments/faketelescope.py
+++ b/src/chimera/instruments/faketelescope.py
@@ -149,27 +149,22 @@ class FakeTelescope(TelescopeBase, TelescopePier):
 
     @lock
     def move_east(self, offset, rate=None):
-        self._slewing = True
-
-        ra, dec = self.get_position_ra_dec()
-        pos = Position.from_ra_dec(ra + Coord.from_as(offset), dec, epoch=Epoch.NOW)
-        self.slew_begin(float(pos.ra), float(pos.dec))
-
-        self._ra += float(Coord.from_as(offset).to_h())
-        self._set_alt_az_from_ra_dec()
-
-        self._slewing = False
-        self.slew_complete(self._ra, self._dec, TelescopeStatus.OK)
+        self._jog_ra(float(Coord.from_as(offset).to_h()))
 
     @lock
     def move_west(self, offset, rate=None):
+        self._jog_ra(-float(Coord.from_as(offset).to_h()))
+
+    def _jog_ra(self, offset):
+        # offset in hours. RA is a clock: a jog either side of 0 h wraps, it
+        # does not run off the end into a Position that refuses to be built
         self._slewing = True
 
-        ra, dec = self.get_position_ra_dec()
-        pos = Position.from_ra_dec(ra + Coord.from_as(-offset), dec)
+        ra = (self.get_ra() + offset) % 24
+        pos = Position.from_ra_dec(ra, self.get_dec(), epoch=Epoch.NOW)
         self.slew_begin(float(pos.ra), float(pos.dec))
 
-        self._ra += float(Coord.from_as(-offset).to_h())
+        self._ra = ra
         self._set_alt_az_from_ra_dec()
 
         self._slewing = False

--- a/src/chimera/instruments/faketelescope.py
+++ b/src/chimera/instruments/faketelescope.py
@@ -161,8 +161,7 @@ class FakeTelescope(TelescopeBase, TelescopePier):
         self._slewing = True
 
         ra = (self.get_ra() + offset) % 24
-        pos = Position.from_ra_dec(ra, self.get_dec(), epoch=Epoch.NOW)
-        self.slew_begin(float(pos.ra), float(pos.dec))
+        self.slew_begin(ra, self.get_dec())
 
         self._ra = ra
         self._set_alt_az_from_ra_dec()

--- a/src/chimera/instruments/faketelescope.py
+++ b/src/chimera/instruments/faketelescope.py
@@ -49,7 +49,7 @@ class FakeTelescope(TelescopeBase, TelescopePier):
     def __start__(self):
         self.set_hz(1)
 
-    def control(self):
+    def _control(self):
         if not self._slewing:
             if self._tracking:
                 self._set_alt_az_from_ra_dec()

--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -25,6 +25,67 @@ class TelescopeBase(
         super().__init__()
 
         self._park_position = None
+        # True once the mount has been seen tracking east of pier_flip_ha, i.e.
+        # heading for the flip. See _check_pier_flip().
+        self._pier_flip_armed = False
+
+        # a pier flip is a minutes-scale event and every check asks the mount
+        # where it is: 2 Hz (the ChimeraObject default) is pointless traffic on
+        # a serial mount. Drivers needing a faster loop call set_hz() in
+        # __start__, which runs after this.
+        self.set_hz(1 / 5.0)
+
+    def control(self) -> bool:
+        """
+        Runs the automatic pier flip check on every cycle of the object's
+        control loop, then the driver's own periodic work. Drivers implement
+        L{_control}.
+        """
+        self._check_pier_flip()
+        return self._control()
+
+    def _control(self) -> bool:
+        """
+        Periodic driver work, called from L{control} on every cycle of the
+        control loop. Runs unlocked, on the control loop thread.
+
+        @return: False to stop the control loop.
+        @rtype: bool
+        """
+        return True
+
+    def _check_pier_flip(self):
+        """
+        Flip a German equatorial mount that has tracked past C{pier_flip_ha}.
+
+        The mount is re-slewed to where it is already pointing, which is what
+        makes it choose the other side of the pier. Only a mount that reached
+        the limit by tracking is flipped: one that slewed straight to an object
+        past the limit is already on the side the mount driver picked for it.
+        """
+        flip_ha = self["pier_flip_ha"]
+        if flip_ha is None:
+            return
+
+        if self.is_slewing() or not self.is_tracking():
+            # wherever the next slew lands is the new starting point
+            self._pier_flip_armed = False
+            return
+
+        ha = self.get_site().ra_to_ha(self.get_ra())
+
+        if ha < flip_ha:
+            self._pier_flip_armed = True
+            return
+
+        if not self._pier_flip_armed:
+            return
+
+        self.log.info(f"Hour angle {ha:.3f} h is past {flip_ha} h, flipping the pier.")
+        self.slew_to_ra_dec(*self.get_position_ra_dec())
+        # only on success: a flip that raised stays armed and is retried on the
+        # next cycle, rather than leaving the mount tracking into the pier
+        self._pier_flip_armed = False
 
     @lock
     def slew_to_object(self, name):

--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -12,7 +12,7 @@ from chimera.interfaces.telescope import (
     TelescopeTracking,
 )
 from chimera.util.coord import Coord
-from chimera.util.position import Position, airmass
+from chimera.util.position import Epoch, Position, airmass
 from chimera.util.simbad import simbad_lookup
 
 __all__ = ["TelescopeBase"]
@@ -73,21 +73,34 @@ class TelescopeBase(
             self._last_ha = None
             return
 
-        ha = self.get_site().ra_to_ha(self.get_ra())
+        ra, dec = self.get_position_ra_dec()
+        ha = self.get_site().ra_to_ha(self._ra_of_date(ra, dec))
 
         if self._last_ha is not None and self._last_ha < flip_ha <= ha:
             self.log.info(
                 f"Hour angle {ha:.3f} h is past {flip_ha} h, flipping the pier."
             )
-            # get_position_ra_dec() and slew_to_ra_dec() are both in the
-            # interface's default epoch, so this re-slews to exactly where the
-            # mount already is, with no precession in or out
-            self.slew_to_ra_dec(*self.get_position_ra_dec(), epoch=2000)
+            # the position went out in the epoch it came back in, so this
+            # re-slews to exactly where the mount already is: it changes side
+            # of pier, not target
+            self.slew_to_ra_dec(ra, dec, epoch=2000)
 
         # last: a flip that raised leaves the crossing unrecorded and is
         # retried on the next cycle, rather than leaving the mount tracking
         # into the pier
         self._last_ha = ha
+
+    def _ra_of_date(self, ra: float, dec: float) -> float:
+        """
+        C{ra} precessed from the J2000 the position accessors answer in to the
+        epoch of date, in hours.
+
+        An hour angle is a difference against the local sidereal time, which is
+        epoch of date: measuring it from a J2000 right ascension is 26 years of
+        accumulated precession out, ~2 minutes of time in 2026 and growing.
+        """
+        of_date = Position.from_ra_dec(ra, dec, epoch=Epoch.J2000).to_epoch(Epoch.NOW)
+        return float(of_date.ra.to_h())
 
     @lock
     def slew_to_object(self, name):

--- a/src/chimera/instruments/telescope.py
+++ b/src/chimera/instruments/telescope.py
@@ -25,9 +25,9 @@ class TelescopeBase(
         super().__init__()
 
         self._park_position = None
-        # True once the mount has been seen tracking east of pier_flip_ha, i.e.
-        # heading for the flip. See _check_pier_flip().
-        self._pier_flip_armed = False
+        # hour angle seen on the previous control cycle, None while slewing or
+        # not tracking. See _check_pier_flip().
+        self._last_ha = None
 
         # a pier flip is a minutes-scale event and every check asks the mount
         # where it is: 2 Hz (the ChimeraObject default) is pointless traffic on
@@ -59,9 +59,10 @@ class TelescopeBase(
         Flip a German equatorial mount that has tracked past C{pier_flip_ha}.
 
         The mount is re-slewed to where it is already pointing, which is what
-        makes it choose the other side of the pier. Only a mount that reached
-        the limit by tracking is flipped: one that slewed straight to an object
-        past the limit is already on the side the mount driver picked for it.
+        makes it choose the other side of the pier. What triggers it is the
+        hour angle crossing the limit between two cycles: a mount that slewed
+        straight to an object already past the limit never crosses it here and
+        is left on the side its driver picked.
         """
         flip_ha = self["pier_flip_ha"]
         if flip_ha is None:
@@ -69,23 +70,24 @@ class TelescopeBase(
 
         if self.is_slewing() or not self.is_tracking():
             # wherever the next slew lands is the new starting point
-            self._pier_flip_armed = False
+            self._last_ha = None
             return
 
         ha = self.get_site().ra_to_ha(self.get_ra())
 
-        if ha < flip_ha:
-            self._pier_flip_armed = True
-            return
+        if self._last_ha is not None and self._last_ha < flip_ha <= ha:
+            self.log.info(
+                f"Hour angle {ha:.3f} h is past {flip_ha} h, flipping the pier."
+            )
+            # get_position_ra_dec() and slew_to_ra_dec() are both in the
+            # interface's default epoch, so this re-slews to exactly where the
+            # mount already is, with no precession in or out
+            self.slew_to_ra_dec(*self.get_position_ra_dec(), epoch=2000)
 
-        if not self._pier_flip_armed:
-            return
-
-        self.log.info(f"Hour angle {ha:.3f} h is past {flip_ha} h, flipping the pier.")
-        self.slew_to_ra_dec(*self.get_position_ra_dec())
-        # only on success: a flip that raised stays armed and is retried on the
-        # next cycle, rather than leaving the mount tracking into the pier
-        self._pier_flip_armed = False
+        # last: a flip that raised leaves the crossing unrecorded and is
+        # retried on the next cycle, rather than leaving the mount tracking
+        # into the pier
+        self._last_ha = ha
 
     @lock
     def slew_to_object(self, name):

--- a/src/chimera/interfaces/telescope.py
+++ b/src/chimera/interfaces/telescope.py
@@ -65,6 +65,10 @@ class TelescopeSlew(Telescope):
         "position_sigma_delta": 60.0,  # arcseconds
         "skip_init": False,
         "min_altitude": 20,
+        # Hour angle, in hours, at which a German equatorial mount that tracked
+        # into it is flipped to the other side of the pier. None (the default)
+        # never flips.
+        "pier_flip_ha": None,
     }
 
     def slew_to_object(self, name: str) -> None:

--- a/src/chimera/util/coord.py
+++ b/src/chimera/util/coord.py
@@ -284,11 +284,24 @@ class CoordUtil:
 
     @staticmethod
     def ra_to_ha(ra, lst):
-        return Coord.from_r(CoordUtil.coord_to_r(lst) - CoordUtil.coord_to_r(ra))
+        """
+        Hour angle of C{ra} at C{lst}, wrapped to +/-12 h: negative east of
+        the meridian, positive west of it. Without the wrap an object either
+        side of the 0/24 h boundary comes back ~24 h away from the meridian
+        it is actually sitting on.
+        """
+        return CoordUtil.make_valid_180_to_180(
+            CoordUtil.coord_to_r(lst) - CoordUtil.coord_to_r(ra)
+        )
 
     @staticmethod
     def ha_to_ra(ha, lst):
-        return Coord.from_r(CoordUtil.coord_to_r(lst) - CoordUtil.coord_to_r(ha))
+        """
+        Right ascension of C{ha} at C{lst}, wrapped to [0, 24) h.
+        """
+        return CoordUtil.make_valid_0_to_360(
+            CoordUtil.coord_to_r(lst) - CoordUtil.coord_to_r(ha)
+        )
 
     # coord_rotate adopted from sidereal.py
     # http://www.nmt.edu/tcc/help/lang/python/examples/sidereal/ims/

--- a/tests/chimera/core/test_site.py
+++ b/tests/chimera/core/test_site.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
 
 import datetime as dt
+import math
 import time
 
 import msgspec
@@ -92,6 +93,17 @@ class TestSite:
 
         with pytest.raises(TypeError):
             encoder.encode(site.sunpos())
+
+    def test_ra_to_ha_is_signed_around_the_meridian(self, manager):
+        """HA comes back in [-12, +12), east of the meridian negative, even
+        for a right ascension on the other side of the 0/24 h wrap."""
+        site = manager.get_proxy("/Site/0")
+        lst = site.lst_in_rads() * 12 / math.pi
+
+        for hour_angle in (-11.5, -1, 0, 1, 11.5):
+            ra = (lst - hour_angle) % 24
+            # the sidereal clock keeps running: 0.01 h is 36 seconds of slack
+            assert site.ra_to_ha(ra) == pytest.approx(hour_angle, abs=0.01)
 
     def test_is_dusk_tracks_the_sun_not_the_clock(self, manager):
         """Dusk is the sun on its way down, sampled all the way around a

--- a/tests/chimera/instruments/test_telescope.py
+++ b/tests/chimera/instruments/test_telescope.py
@@ -6,6 +6,7 @@ import logging
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
+from types import SimpleNamespace
 
 import pytest
 
@@ -213,6 +214,28 @@ class TestFakeTelescope:
                 (start_dec - dec) * 3600,
             )
             assert (start_ra, start_dec) != (ra, dec)
+
+
+def test_jog_wraps_ra_at_the_clock(monkeypatch):
+    """A jog either side of 0 h stays on the clock: RA 0.05 h jogged 6 minutes
+    west is 23.95 h, not the negative RA Position refuses to be built from."""
+    telescope = FakeTelescope()
+    monkeypatch.setattr(
+        telescope,
+        "get_site",
+        lambda: SimpleNamespace(ra_dec_to_alt_az=lambda ra, dec: (60.0, 30.0)),
+    )
+    for event in ("slew_begin", "slew_complete"):
+        monkeypatch.setattr(FakeTelescope, event, lambda *args: None, raising=False)
+
+    telescope._ra, telescope._dec = 0.05, -30.0
+    six_minutes = float(Coord.from_h(0.1).to_as())
+
+    telescope.move_west(six_minutes)
+    assert telescope.get_ra() == pytest.approx(23.95)
+
+    telescope.move_east(six_minutes)
+    assert telescope.get_ra() == pytest.approx(0.05)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/chimera/instruments/test_telescope.py
+++ b/tests/chimera/instruments/test_telescope.py
@@ -10,7 +10,9 @@ from concurrent.futures import ThreadPoolExecutor, wait
 import pytest
 
 import chimera.core.log
+from chimera.core.exceptions import ChimeraException
 from chimera.instruments.faketelescope import FakeTelescope
+from chimera.instruments.telescope import TelescopeBase
 from chimera.interfaces.telescope import TelescopeStatus
 from chimera.util.coord import Coord
 
@@ -211,3 +213,168 @@ class TestFakeTelescope:
                 (start_dec - dec) * 3600,
             )
             assert (start_ra, start_dec) != (ra, dec)
+
+
+# ---------------------------------------------------------------------------
+# Automatic pier flip (unit level, no bus): TelescopeBase.control() re-slews a
+# mount that tracked past pier_flip_ha.
+# ---------------------------------------------------------------------------
+
+
+class PierTelescope(TelescopeBase):
+    """Just enough telescope to drive the pier flip check by hand."""
+
+    def __init__(self):
+        TelescopeBase.__init__(self)
+
+        self.ha = -1.0  # hour angle the site will report, in hours
+        self.tracking = True
+        self.slewing = False
+        self.slews = []
+        self.controls = 0
+        self.slew_error = None
+
+    def _control(self):
+        self.controls += 1
+        return True
+
+    def is_slewing(self):
+        return self.slewing
+
+    def is_tracking(self):
+        return self.tracking
+
+    def get_ra(self):
+        return 12.0
+
+    def get_dec(self):
+        return -30.0
+
+    def get_position_ra_dec(self):
+        return self.get_ra(), self.get_dec()
+
+    def slew_to_ra_dec(self, ra, dec, epoch=2000):
+        if self.slew_error is not None:
+            raise self.slew_error
+        self.slews.append((ra, dec))
+
+
+@pytest.fixture
+def pier_telescope(monkeypatch):
+    def factory(**config):
+        telescope = PierTelescope()
+        for key, value in config.items():
+            telescope[key] = value
+
+        monkeypatch.setattr(
+            telescope,
+            "get_site",
+            lambda: type("site", (), {"ra_to_ha": lambda _, ra: telescope.ha})(),
+        )
+        return telescope
+
+    return factory
+
+
+class TestPierFlip:
+    def test_disabled_by_default(self, pier_telescope):
+        telescope = pier_telescope()
+
+        telescope.ha = -0.1
+        telescope.control()
+        telescope.ha = +0.1
+        telescope.control()
+
+        assert telescope.slews == []
+        # the driver's own periodic work still runs on every cycle
+        assert telescope.controls == 2
+
+    def test_tracking_past_the_limit_flips(self, pier_telescope):
+        telescope = pier_telescope(pier_flip_ha=0)
+
+        telescope.ha = -0.1
+        telescope.control()
+        assert telescope.slews == []
+
+        telescope.ha = +0.1
+        telescope.control()
+        assert telescope.slews == [(12.0, -30.0)]
+
+    def test_flips_only_once(self, pier_telescope):
+        telescope = pier_telescope(pier_flip_ha=0)
+
+        telescope.ha = -0.1
+        telescope.control()
+
+        for telescope.ha in (0.1, 0.2, 0.3):
+            telescope.control()
+
+        assert telescope.slews == [(12.0, -30.0)]
+
+    def test_a_slew_past_the_limit_does_not_flip(self, pier_telescope):
+        """The mount never tracked into the limit: the driver put it on
+        whichever side it wanted when it slewed there."""
+        telescope = pier_telescope(pier_flip_ha=0)
+
+        telescope.ha = +1.0
+        telescope.control()
+        telescope.ha = +1.5
+        telescope.control()
+
+        assert telescope.slews == []
+
+    def test_slewing_disarms_the_flip(self, pier_telescope):
+        telescope = pier_telescope(pier_flip_ha=0)
+
+        telescope.ha = -0.1
+        telescope.control()
+
+        telescope.slewing = True
+        telescope.ha = +0.1
+        telescope.control()
+
+        telescope.slewing = False
+        telescope.control()
+
+        assert telescope.slews == []
+
+    def test_a_parked_mount_is_not_flipped(self, pier_telescope):
+        telescope = pier_telescope(pier_flip_ha=0)
+
+        telescope.ha = -0.1
+        telescope.control()
+
+        telescope.tracking = False
+        telescope.ha = +0.1
+        telescope.control()
+
+        assert telescope.slews == []
+
+    def test_the_limit_is_configurable(self, pier_telescope):
+        telescope = pier_telescope(pier_flip_ha=0.5)
+
+        for telescope.ha in (-0.1, 0.1, 0.4):
+            telescope.control()
+        assert telescope.slews == []
+
+        telescope.ha = 0.6
+        telescope.control()
+        assert telescope.slews == [(12.0, -30.0)]
+
+    def test_a_failed_flip_is_retried(self, pier_telescope):
+        """The mount is tracking into the pier: giving up quietly is the one
+        thing the check must not do."""
+        telescope = pier_telescope(pier_flip_ha=0)
+
+        telescope.ha = -0.1
+        telescope.control()
+
+        telescope.slew_error = ChimeraException("mount is not answering")
+        telescope.ha = +0.1
+        with pytest.raises(ChimeraException):
+            telescope.control()
+        assert telescope.slews == []
+
+        telescope.slew_error = None
+        telescope.control()
+        assert telescope.slews == [(12.0, -30.0)]

--- a/tests/chimera/instruments/test_telescope.py
+++ b/tests/chimera/instruments/test_telescope.py
@@ -16,6 +16,7 @@ from chimera.instruments.faketelescope import FakeTelescope
 from chimera.instruments.telescope import TelescopeBase
 from chimera.interfaces.telescope import TelescopeStatus
 from chimera.util.coord import Coord
+from chimera.util.position import Epoch, Position
 
 chimera.core.log.set_console_level(int(1e10))
 log = logging.getLogger("chimera.tests")
@@ -256,6 +257,7 @@ class PierTelescope(TelescopeBase):
         self.slews = []
         self.controls = 0
         self.slew_error = None
+        self.hour_angle_args = []
 
     def _control(self):
         self.controls += 1
@@ -289,10 +291,12 @@ def pier_telescope(monkeypatch):
         for key, value in config.items():
             telescope[key] = value
 
+        def ra_to_ha(ra):
+            telescope.hour_angle_args.append(ra)
+            return telescope.ha
+
         monkeypatch.setattr(
-            telescope,
-            "get_site",
-            lambda: type("site", (), {"ra_to_ha": lambda _, ra: telescope.ha})(),
+            telescope, "get_site", lambda: SimpleNamespace(ra_to_ha=ra_to_ha)
         )
         return telescope
 
@@ -324,6 +328,23 @@ class TestPierFlip:
         # same position, same epoch the position accessors answer in: the
         # mount changes side of pier, not target
         assert telescope.slews == [(12.0, -30.0, 2000)]
+
+    def test_the_hour_angle_is_measured_in_the_epoch_of_date(self, pier_telescope):
+        """The position accessors answer in J2000; the local sidereal time an
+        hour angle is measured against is epoch of date. Subtracting one from
+        the other is 26 years of precession out -- ~2 minutes of time in 2026,
+        and more every year -- so the flip fires early."""
+        telescope = pier_telescope(pier_flip_ha=0)
+
+        telescope.control()
+
+        (ra,) = telescope.hour_angle_args
+        of_date = Position.from_ra_dec(12.0, -30.0, epoch=Epoch.J2000).to_epoch(
+            Epoch.NOW
+        )
+        assert ra == pytest.approx(float(of_date.ra.to_h()))
+        # a quarter century of precession, not the J2000 number it started from
+        assert 0.01 < ra - 12.0 < 0.05
 
     def test_flips_only_once(self, pier_telescope):
         telescope = pier_telescope(pier_flip_ha=0)

--- a/tests/chimera/instruments/test_telescope.py
+++ b/tests/chimera/instruments/test_telescope.py
@@ -256,7 +256,7 @@ class PierTelescope(TelescopeBase):
     def slew_to_ra_dec(self, ra, dec, epoch=2000):
         if self.slew_error is not None:
             raise self.slew_error
-        self.slews.append((ra, dec))
+        self.slews.append((ra, dec, epoch))
 
 
 @pytest.fixture
@@ -298,7 +298,9 @@ class TestPierFlip:
 
         telescope.ha = +0.1
         telescope.control()
-        assert telescope.slews == [(12.0, -30.0)]
+        # same position, same epoch the position accessors answer in: the
+        # mount changes side of pier, not target
+        assert telescope.slews == [(12.0, -30.0, 2000)]
 
     def test_flips_only_once(self, pier_telescope):
         telescope = pier_telescope(pier_flip_ha=0)
@@ -309,7 +311,7 @@ class TestPierFlip:
         for telescope.ha in (0.1, 0.2, 0.3):
             telescope.control()
 
-        assert telescope.slews == [(12.0, -30.0)]
+        assert telescope.slews == [(12.0, -30.0, 2000)]
 
     def test_a_slew_past_the_limit_does_not_flip(self, pier_telescope):
         """The mount never tracked into the limit: the driver put it on
@@ -359,7 +361,7 @@ class TestPierFlip:
 
         telescope.ha = 0.6
         telescope.control()
-        assert telescope.slews == [(12.0, -30.0)]
+        assert telescope.slews == [(12.0, -30.0, 2000)]
 
     def test_a_failed_flip_is_retried(self, pier_telescope):
         """The mount is tracking into the pier: giving up quietly is the one
@@ -377,4 +379,4 @@ class TestPierFlip:
 
         telescope.slew_error = None
         telescope.control()
-        assert telescope.slews == [(12.0, -30.0)]
+        assert telescope.slews == [(12.0, -30.0, 2000)]

--- a/tests/chimera/util/test_coord.py
+++ b/tests/chimera/util/test_coord.py
@@ -3,7 +3,7 @@ import time
 
 from astropy.io import ascii
 
-from chimera.util.coord import Coord
+from chimera.util.coord import Coord, CoordUtil
 
 
 class TestCoord:
@@ -159,3 +159,34 @@ class TestCoord:
         print(
             f"#{len(coords)} coords parsed in {t_parse:.3f}s ({len(coords) / t_parse:.3f}/s) and checked in {t_check:.3f}s ({len(coords) / t_check:.3f}/s) ..."
         )
+
+
+class TestHourAngle:
+    """
+    ra_to_ha() and ha_to_ra() answer in the conventional ranges, including
+    across the 0/24 h boundary, where a bare lst - ra is ~24 h out.
+    """
+
+    def test_ra_to_ha_is_signed_around_the_meridian(self):
+        for lst, ra, ha in [
+            (2.0, 1.0, +1.0),  # west of the meridian
+            (1.0, 2.0, -1.0),  # east of it
+            (12.0, 12.0, 0.0),  # on it
+            (0.5, 23.5, +1.0),  # one hour past, across the wrap
+            (23.5, 0.5, -1.0),  # one hour short of it, across the wrap
+        ]:
+            assert TestCoord.equal(
+                float(CoordUtil.ra_to_ha(Coord.from_h(ra), Coord.from_h(lst)).to_h()),
+                ha,
+            )
+
+    def test_ha_to_ra_stays_on_the_clock(self):
+        for lst, ha, ra in [
+            (2.0, 1.0, 1.0),
+            (0.5, 1.0, 23.5),  # would be -0.5 h without the wrap
+            (23.5, -1.0, 0.5),
+        ]:
+            assert TestCoord.equal(
+                float(CoordUtil.ha_to_ra(Coord.from_h(ha), Coord.from_h(lst)).to_h()),
+                ra,
+            )


### PR DESCRIPTION
Folds the [chimera-autopierchange](https://github.com/astroufsc/chimera-autopierchange) plugin into the telescope itself, the way per-filter focus offsets went into `FilterWheelBase` in #259. A German equatorial mount that cannot be trusted to track past the meridian is not something a controller should be watching from outside; it is part of what driving that mount means.

## What changes

`TelescopeBase.control()` becomes concrete: it runs the pier flip check on every cycle and then calls the driver's new `_control()` primitive. Drivers keep their periodic work and stop deciding whether the control loop runs at all. `FakeTelescope` is migrated here.

```yaml
telescope:
  name: fake
  type: FakeTelescope
  pier_flip_ha: 0     # hours; 0 flips at the meridian, 0.5 buys 30 more minutes
```

Leaving `pier_flip_ha` unset — the default, and the whole story on a fork or alt-az mount — returns before the check asks the mount anything.

The mount is flipped by re-slewing it to the position it is already pointing at, which is what makes it pick the other side of the pier. What triggers it is the hour angle crossing the limit between two control cycles, so only a mount that reached the limit **by tracking** is flipped: one that slewed straight to an object already past it never produces a crossing and is left on the side its own driver chose.

Two epochs meet in that check and they are not the same one. The position accessors answer in J2000, so the re-slew hands the position straight back with `epoch=2000` and the mount changes side of pier, not target. The hour angle, though, is a difference against the local sidereal time, which is epoch of date: `_ra_of_date()` precesses the right ascension forward before the subtraction. Measured against the mount at LNA, a J2000 right ascension put the flip **~2 minutes early** in 2026 (RA 21.48354 h J2000 vs 21.51615 h of date at dec −58.8°), growing by 3.075 + 1.336·sin α·tan δ seconds a year.

### `control()` → `_control()`, for driver authors

Any telescope driver that defines `control()` keeps working, but overrides the base and so never runs the flip check. Renaming it to `_control()` is the whole migration. In-tree, `FakeTelescope` is done here; out of tree: astroufsc/chimera-astelco#10 and astroufsc/chimera-bisque#11 (the legacy TheSky COM driver). `TheSkyXTelescope`, `AlpacaTelescope` and anything else that never overrode `control()` need no change.

Related: `TelescopeBase.__init__` now sets the loop to 0.2 Hz, so a driver that did periodic work in `control()` at the 2 Hz `ChimeraObject` default gets it ten times slower once it renames. Call `set_hz()` in `__start__`, which runs after `__init__`, to keep the old rate.

The telescope's loop rate drops to one cycle every 5 s, since what the base now runs there asks the mount where it is and a flip is a minutes-scale event. A driver wanting a faster loop still calls `set_hz()` in `__start__`, which runs after `__init__`.

## Why not leave it in the plugin

- **It inferred the pier side from the hour angle at the end of every slew**, and stored it in `TelescopePierSide` with the opposite sense of the ASCOM convention that enum otherwise carries (`pierEast` is the *normal* pointing state, looking west). It also only saw the slews it was subscribed for, so a restart mid-target left it on `UNKNOWN` forever. Here the trigger is the crossing itself, read fresh each cycle from the previous hour angle and the current one, so a chimera restarted mid-target simply waits for the next one instead of guessing.
- **Its hour angle was a bare `lst - ra`, never wrapped.** With LST at 0.5 h and a target at RA 23.5 h — one hour past the meridian, i.e. overdue — it computed −23 h and concluded there were 23 hours to go. The flip never came. Measured on the mount at LNA before the fix: a target 2.77 h west of the meridian came back as **−21.23 h**. Fixed at the root in `CoordUtil.ra_to_ha()`, which wraps to ±12 h, in its own commit; `ha_to_ra()` had the mirror image of it and now wraps to `[0, 24)`. **This changes `CoordUtil` for every caller** — the only other in-tree consumer is `position.py:433`, where the value goes into `coord_rotate()` through trig and alt/az is unaffected (verified on the deployed build).
- **A failed flip was swallowed** by a blanket `except Exception` around the whole loop body. The mount is tracking into the pier at that point, so this is the one failure that must not be quiet: the check now stays armed and retries on the next cycle, and the exception reaches the control loop, which logs it (#272).

Two options are gone. `dome` (the plugin re-synced the dome itself): the flip fires `slew_begin`/`slew_complete` like any other slew, so a dome in `track` mode follows on its own. `check_interval`: the check runs on the object's existing control loop.

## Compatibility

Users of the plugin drop the `AutoPierChange` controller block and move `ha_flip` onto the telescope as `pier_flip_ha`; documented in `docs/configuring.rst`.

## Testing

10 new tests in `tests/chimera/instruments/test_telescope.py` cover the crossing, the flip firing exactly once (with its epoch), a slew that lands past the limit not flipping, slewing and not-tracking resetting the check, a non-zero limit, the driver's `_control()` still running every cycle, a failed flip being retried, and the hour angle being measured in the epoch of date rather than J2000, plus one on the RA wrap below. Two in `tests/chimera/util/test_coord.py` pin both hour angle conversions across the 0/24 h wrap, and one in `tests/chimera/core/test_site.py` checks `Site.ra_to_ha()` keeps the convention. Full suite: 277 passed, 8 skipped.

CI went red on the review-fixup commit, on `TestFakeTelescope::test_jog` — not from anything here. That test jogs west from wherever alt 60/az 30 happens to be, and when the sidereal clock puts that near RA 0 h, `FakeTelescope.move_west()` walks the RA negative and `Position.from_ra_dec()` refuses it. It has been latent on `master` all along and only fires in a couple of hours out of every 24; the last commit wraps the jog and pins it with a test that does not wait for the LST to come round.

Verified end to end against a live `chimera` with `FakeTelescope` and the site clock at 60× sidereal, slewing to 18 minutes east of the meridian and letting it track across:

```
LST is 19.8316 h; slewing to RA 20.1316 h (HA -0.3000 h)
slew done, tracking=True, HA=-0.2158
  t+  0.0s  HA=-0.2158 h  flips=0
  ...
  t+ 13.1s  HA=+0.0028 h  flips=0
  t+ 14.1s  HA=+0.0196 h  flips=1
PIER FLIP: re-slewed to 20.1316 -22.5000 at HA +0.0196
flips after another 5 s: 1
```

```
$ chimera-tel --info
telescope: tcp://127.0.0.1:7667/FakeTelescope/fake, device=None
current position ra/dec: 20:07:53.711/-22:30:00.000
current position alt/az: +86:37:04.490/17:59:31.701
tracking: enabled
current side of pier: unknown
automatic pier flip: at hour angle 0 h
```

and in the server log:

```
INFO chimera.faketelescope telescope.py:78 Hour angle 0.009 h is past 0 h, flipping the pier.
```
