### PR TITLE
site: add sun_azimuth(), the plain-float companion to sun_altitude()

### DIFF
--- a/src/chimera/core/site.py
+++ b/src/chimera/core/site.py
@@ -216,6 +216,21 @@ class Site(ChimeraObject):
         self._sun.compute(self._get_ephem(date))
         return float(Coord.from_r(self._sun.alt).to_d())
 
+    def sun_azimuth(self, date=None):
+        """
+        Sun azimuth in DEGREES.
+
+        The companion to sun_altitude(), and for the same reason: reading
+        sunpos().az drags a Position across the bus, which is not
+        serializable. Anything pointing away from the Sun needs this -
+        twilight sky flats shoot the anti-solar point, 180 degrees from it.
+
+        @rtype: float
+        """
+        date = date or self.ut()
+        self._sun.compute(self._get_ephem(date))
+        return float(Coord.from_r(self._sun.az).to_d())
+
     def is_dusk(self, date=None):
         """
         True while the Sun is on its way down, False while it is climbing.

--- a/tests/chimera/core/test_site.py
+++ b/tests/chimera/core/test_site.py
@@ -82,13 +82,22 @@ class TestSite:
         assert site.sun_altitude(when) == pytest.approx(float(site.sunpos(when).alt))
         assert site.sun_altitude() == pytest.approx(float(site.sunpos().alt), abs=0.01)
 
-    def test_sun_altitude_survives_the_bus(self, manager):
+    def test_sun_azimuth_is_the_azimuth_in_degrees(self, manager):
+        site = manager.get_proxy("/Site/0")
+
+        when = dt.datetime(2026, 7, 27, 16, 0, tzinfo=dt.UTC)
+
+        assert site.sun_azimuth(when) == pytest.approx(float(site.sunpos(when).az))
+        assert site.sun_azimuth() == pytest.approx(float(site.sunpos().az), abs=0.01)
+
+    def test_sun_accessors_survive_the_bus(self, manager):
         """A Position cannot be encoded, so sunpos() only works between
-        objects sharing a bus - the reason for a plain-float accessor."""
+        objects sharing a bus - the reason for the plain-float accessors."""
         site = manager.get_proxy("/Site/0")
 
         encoder = msgspec.json.Encoder()
         assert encoder.encode(site.sun_altitude())
+        assert encoder.encode(site.sun_azimuth())
 
         with pytest.raises(TypeError):
             encoder.encode(site.sunpos())


### PR DESCRIPTION
#275 added `sun_altitude()` so nothing needs to read `sunpos()` across the bus — a `Position` is not msgspec-encodable — but left the azimuth without an accessor. Anything pointing away from the Sun still had to call `sunpos()`: chimera-skyflat aims its flats at the anti-solar point, and on opd-40 (2026-07-28 twilight) it logged

```
ERROR bus: serialization issue, won't work on remote buses: Response(... result=<chimera.util.position.Position object ...>)
TypeError: Encoding objects of type Position is unsupported
```

on every control cycle.

Same shape as `sun_altitude()`: degrees, optional `date`, one `_sun.compute()`. Tests mirror #275's — the value matches `sunpos().az` and the answer survives msgspec encoding.