### PR TITLE
site: make the observable night's boundary configurable

### DIFF
--- a/src/chimera/core/site.py
+++ b/src/chimera/core/site.py
@@ -3,6 +3,7 @@
 
 
 import datetime as dt
+import math
 import threading
 
 import ephem
@@ -42,7 +43,19 @@ class Site(ChimeraObject):
         # "start now" (pure speedup with no jump).
         time_speedup=1.0,
         time_start="",
+        # Sun altitudes, in DEGREES, bounding the observable night.
+        #
+        # "night" is the schedulers' observing window (sunset_twilight_end
+        # .. sunrise_twilight_begin); raise it at a site whose twilight
+        # calibrations cannot start that low. "twilight" is the outer
+        # bracket (sunset_twilight_begin, sunrise_twilight_end) and must
+        # sit ABOVE it; omit it to derive it 6 deg above "night".
+        horizon={"night": -18.0, "twilight": -12.0},
     )
+
+    #: derived bracket offset above horizon["night"]; 6 gives the
+    #: historical -18/-12 pair
+    TWILIGHT_BRACKET_OFFSET = 6.0
 
     def __init__(self):
         super().__init__()
@@ -58,6 +71,47 @@ class Site(ChimeraObject):
         self._ff_wall0 = None
         self._ff_sim0 = None
 
+    def __start__(self):
+        # An inverted pair turns every window inside out; fail here rather
+        # than at the first dusk.
+        night, twilight = self._night_horizons()
+        if not night < twilight:
+            raise ValueError(
+                f"horizon['night'] ({night:g} deg) must be BELOW "
+                f"horizon['twilight'] ({twilight:g} deg): the sun reaches "
+                "the twilight bracket first at dusk and last at dawn."
+            )
+        if night != -18.0:
+            self.log.info(
+                f"Observable night bounded at sun altitude {night:g} deg "
+                f"(twilight bracket {twilight:g} deg)."
+            )
+        return True
+
+    def _night_horizons(self):
+        """(night, twilight) sun altitudes in degrees, bracket derived when
+        "twilight" is not given."""
+        horizon = self["horizon"] or {}
+
+        unknown = sorted(set(horizon) - {"night", "twilight"})
+        if unknown:
+            raise ValueError(
+                f"Unknown horizon key(s) {unknown}: expected 'night' and 'twilight'."
+            )
+
+        try:
+            night = float(horizon.get("night", -18.0))
+            twilight = horizon.get("twilight")
+            twilight = (
+                night + self.TWILIGHT_BRACKET_OFFSET
+                if twilight is None or str(twilight).strip() == ""
+                else float(twilight)
+            )
+        except (TypeError, ValueError):
+            raise ValueError(f"Horizon values must be numbers, got {horizon!r}.")
+
+        return night, twilight
+
     def __main__(self):
         pass
 
@@ -69,6 +123,16 @@ class Site(ChimeraObject):
         site.date = date or self.ut()
         site.epoch = "2000/1/1 00:00:00"
         return site
+
+    def _horizon(self, which):
+        """A configured sun altitude as ephem wants it.
+
+        ephem reads a float horizon as RADIANS and a string as degrees;
+        the config is in degrees, so convert explicitly rather than relying
+        on which type happens to arrive.
+        """
+        night, twilight = self._night_horizons()
+        return math.radians(night if which == "night" else twilight)
 
     def _date_to_local(self, date):
         # convert date to a non-naive datetime with TZ set to UTC
@@ -168,28 +232,30 @@ class Site(ChimeraObject):
         date = date or self.ut()
         site = self._get_ephem(date)
         site.elev = 0
-        site.horizon = "-12:00:00"
+        site.horizon = self._horizon("twilight")
         return self._date_to_local(site.next_setting(self._sun))
 
     def sunset_twilight_end(self, date=None):
+        """The instant the observable night BEGINS (horizon['night'])."""
         date = date or self.ut()
         site = self._get_ephem(date)
         site.elev = 0
-        site.horizon = "-18:00:00"
+        site.horizon = self._horizon("night")
         return self._date_to_local(site.next_setting(self._sun))
 
     def sunrise_twilight_begin(self, date=None):
+        """The instant the observable night ENDS (horizon['night'])."""
         date = date or self.ut()
         site = self._get_ephem(date)
         site.elev = 0
-        site.horizon = "-18:00:00"
+        site.horizon = self._horizon("night")
         return self._date_to_local(site.next_rising(self._sun))
 
     def sunrise_twilight_end(self, date=None):
         date = date or self.ut()
         site = self._get_ephem(date)
         site.elev = 0
-        site.horizon = "-12:00:00"
+        site.horizon = self._horizon("twilight")
         return self._date_to_local(site.next_rising(self._sun))
 
     def sunpos(self, date=None):

--- a/tests/chimera/core/test_site.py
+++ b/tests/chimera/core/test_site.py
@@ -114,3 +114,80 @@ class TestSite:
                 when + dt.timedelta(minutes=1)
             ) < site.sun_altitude(when)
             assert site.is_dusk(when) is descending, f"{when} is not settled"
+
+    def test_the_night_boundary_defaults_to_astronomical_twilight(self, manager):
+        """-18 deg was hardcoded before it was configurable; the default has
+        to reproduce it exactly or every existing schedule shifts."""
+        site = manager.get_proxy("/Site/0")
+
+        when = dt.datetime(2026, 7, 27, 12, 0, tzinfo=dt.UTC)
+
+        assert site["horizon"]["night"] == -18.0
+
+        # next_setting() places the sun's UPPER LIMB on the horizon while
+        # sun_altitude() reports its centre, so the altitude at the returned
+        # instant sits one solar semi-diameter (~0.27 deg) lower
+        assert site.sun_altitude(site.sunset_twilight_end(when)) == pytest.approx(
+            -18.0, abs=0.3
+        )
+        assert site.sun_altitude(site.sunrise_twilight_begin(when)) == pytest.approx(
+            -18.0, abs=0.3
+        )
+        # the bracket is derived, not pinned: -18 + 6 = the historical -12
+        assert site.sun_altitude(site.sunset_twilight_begin(when)) == pytest.approx(
+            -12.0, abs=0.3
+        )
+
+    def test_raising_the_night_horizon_lengthens_the_night(self, manager):
+        """Raising the boundary EXTENDS the observing window at both ends:
+        descending, the sun reaches -8 before -18, so the night starts
+        earlier; rising, it reaches -8 after -18, so it ends later. That is
+        the point - a site whose twilight calibrations cannot begin until
+        -8 should keep observing until then instead of handing the sky over
+        at -18 and waiting (lna40 PENDING_ISSUES 50)."""
+        from chimera.core.site import Site
+
+        site = manager.get_proxy("/Site/0")
+        when = dt.datetime(2026, 7, 27, 12, 0, tzinfo=dt.UTC)
+        dusk18, dawn18 = (
+            site.sunset_twilight_end(when),
+            site.sunrise_twilight_begin(when),
+        )
+
+        manager.add_class(Site, "longnight", {"horizon": {"night": -8.0}}, True)
+        try:
+            short = manager.get_proxy("/Site/longnight")
+
+            assert short.sun_altitude(short.sunset_twilight_end(when)) == pytest.approx(
+                -8.0, abs=0.3
+            )
+            # the derived bracket followed it and stayed above: -8 + 6 = -2
+            assert short.sun_altitude(
+                short.sunset_twilight_begin(when)
+            ) == pytest.approx(-2.0, abs=0.3)
+            # starts earlier at dusk, ends later at dawn: strictly more sky
+            assert short.sunset_twilight_end(when) < dusk18
+            assert short.sunrise_twilight_begin(when) > dawn18
+        finally:
+            manager.remove("/Site/longnight")
+
+    def test_an_inverted_horizon_pair_is_refused_at_startup(self, manager):
+        """a twilight bracket below the night boundary turns every window inside
+        out; fail at start rather than at the first dusk."""
+        from chimera.core.site import Site
+
+        with pytest.raises(Exception):
+            manager.add_class(
+                Site,
+                "inverted",
+                {"horizon": {"night": -6.0, "twilight": -12.0}},
+                True,
+            )
+
+    def test_an_unknown_horizon_key_is_refused(self, manager):
+        """A dict option cannot be spell-checked by the config layer, so a
+        typo would silently fall back to the defaults."""
+        from chimera.core.site import Site
+
+        with pytest.raises(Exception):
+            manager.add_class(Site, "typo", {"horizon": {"nite": -8.0}}, True)


### PR DESCRIPTION
`sunset_twilight_end()` and `sunrise_twilight_begin()` hardcoded a `-18:00:00` horizon, and every scheduler downstream inherits that pair as its night window — chimera-robobs builds `obs_start`/`obs_end` from it, the SkyFlat algorithm anchors its morning set on `obs_end`, and observatory checklists key their start/stop items off the same two instants.

That is fine until a site's twilight calibrations cannot begin at -18. On opd-40 the morning sky flats are anchored at -18 deg (08:18 UT) but `AutoSkyFlat` cannot expose before -8 deg (09:04) and the first filter is not exposable until 09:17 — so the scheduler handed the telescope to the flats **46 minutes** before a frame was possible and sat waiting, with usable sky overhead the whole time.

### What changes

`night_horizon` (degrees, default **-18**) sets the pair that bounds the observable night. Raising it **lengthens** the night at both ends — descending, the sun reaches -8 before -18, so the night starts earlier; rising, it reaches -8 after -18, so it ends later. A site can now keep observing until the sky is genuinely too bright for it instead of handing over at a constant.

`twilight_horizon` sets the outer bracket used by `sunset_twilight_begin()` / `sunrise_twilight_end()`. **Left empty it tracks `night_horizon` 6 deg higher**, which reproduces the historical -18/-12 pair exactly and keeps the ordering correct for any boundary a site picks — otherwise raising `night_horizon` to -8 would leave the -12 "beginning of twilight" being crossed *after* the "end", inverting every window built from the two. Pinning it below `night_horizon` is refused in `__start__`, so the mistake surfaces at startup rather than at the first dusk.

### Compatibility

Defaults are unchanged and a test pins the -18/-12 pair to the altitudes the string constants produced. Note `next_setting()` places the sun's **upper limb** on the horizon while `sun_altitude()` reports its **centre**, so the altitude at the returned instant sits one solar semi-diameter (~0.27 deg) lower — the tests allow for that rather than pretending it is exact.

Three tests: the default reproduces astronomical twilight, raising the boundary extends the window at both ends (with the derived bracket following it), and an inverted pinned pair fails to start.

Closes the first direction of lna40 PENDING_ISSUES 50.
