### PR TITLE
telescope: let OPTICS be free-form text

### DIFF
--- a/src/chimera/interfaces/telescope.py
+++ b/src/chimera/interfaces/telescope.py
@@ -40,11 +40,12 @@ class Telescope(Interface):
     __config__ = {
         "device": None,
         "model": "Fake Telescopes Inc.",
-        "optics": ["Newtonian", "SCT", "RCT"],
+        # free-form OPTICS header text (Newtonian, SCT, RCT, CDK, ...)
+        "optics": "Newtonian",
         "mount": "Mount type Inc.",
         "aperture": 100.0,  # mm
-        "focal_length": 1000.0,  # mm unit (ex., 0.5 for a half length focal reducer)
-        "focal_reduction": 1.0,
+        "focal_length": 1000.0,  # mm
+        "focal_reduction": 1.0,  # ex., 0.5 for a half length focal reducer
         "fans": [],  # List of fans of the telescope, i.e.: ['/FakeFan/fake1', '/FakeFan/fake2']
     }
 


### PR DESCRIPTION
`Telescope.__config__["optics"]` was declared as an option list `["Newtonian", "SCT", "RCT"]`, which chimera's `Config` turns into a closed enumeration (`OptionsChecker`): the default is the first element and anything else raises `OptionConversionException`, stopping the whole system at startup.

That means an observatory whose OTA is not one of those three — a corrected Dall-Kirkham, a Ritchey-Chrétien, a refractor — cannot set the keyword at all. Concretely, the LNA 40 cm (PlaneWave CDK17) currently has to publish `OPTICS = 'Newtonian'` in every frame.

The value is never used for anything but being copied into the `OPTICS` FITS header as descriptive text (`TelescopeBase.get_metadata`), so there is nothing for the enumeration to protect. This declares it as a plain string with `Newtonian` as the default.

- No behaviour change for existing configs: the default is the same value, and `SCT`/`RCT` keep working (now as ordinary strings).
- Drive-by: the `# mm unit (ex., 0.5 for a half length focal reducer)` comment was on `focal_length`, where the parenthetical belongs to `focal_reduction` on the next line.

Verified: `Config(Telescope)` defaults to `Newtonian` and now accepts `SCT`, `RCT` and `Corrected Dall-Kirkham`.