### PR TITLE
scheduler: pick by eligibility, not by a static time sort

### DIFF
--- a/src/chimera/controllers/scheduler/sequential.py
+++ b/src/chimera/controllers/scheduler/sequential.py
@@ -1,75 +1,116 @@
 import logging
-from queue import Queue
 
-from sqlalchemy import desc
+from sqlalchemy import desc, or_
 
 from chimera.controllers.scheduler.ischeduler import IScheduler
 from chimera.controllers.scheduler.model import Program, Session
 
 log = logging.getLogger(__name__)
 
+#: Order among programs that are all ready to run RIGHT NOW: priority first,
+#: then the earliest start_at, then insertion order - a hand-written
+#: `chimera-sched --new` queue runs in the order the targets appear in the
+#: YAML, which is what anyone writing that file expects (they used to come
+#: out reversed).
+_READY_ORDER = (
+    desc(Program.priority),
+    Program.start_at.asc().nullsfirst(),
+    Program.id.asc(),
+)
+
+#: Order when nothing is ready yet: whatever becomes ready soonest.
+_WAITING_ORDER = (Program.start_at.asc(), desc(Program.priority), Program.id.asc())
+
+#: The static order, used only where there is no clock to judge eligibility
+#: with (bare test harnesses).
+_STATIC_ORDER = (
+    Program.start_at.asc().nullsfirst(),
+    desc(Program.priority),
+    Program.id.asc(),
+)
+
 
 class SequentialScheduler(IScheduler):
     def __init__(self):
-        self.run_queue = None
         self.machine = None
+        # programs that errored since the last reschedule: skipped by
+        # __next__ so a failing program cannot livelock the machine, and
+        # retried once the queue is rebuilt (the FIFO this replaced behaved
+        # the same way - popped meant not offered again until a reschedule)
+        self._deferred = set()
 
     def reschedule(self, machine):
         self.machine = machine
-        # a plain thread-safe FIFO, rebuilt on every reschedule; we never
-        # join() it, so no task_done() accounting (which drifts across the
-        # rebuild and raised "task_done() called too many times")
-        self.run_queue = Queue(-1)
+        self._deferred = set()
 
         session = Session()
-
-        # FIXME: remove noqa
-        # start_at orders execution, priority breaks ties: priority alone
-        # let a future-timed program hold the machine with the whole night
-        # queued behind it. Programs without start_at sort first and keep
-        # the old priority order among themselves; equal priorities then run
-        # in insertion order, which for a hand-written `chimera-sched --new`
-        # queue is the order the targets appear in the YAML (they came out
-        # reversed, which is not what anyone writing a file expects).
-        programs = (
-            session.query(Program)
-            .order_by(
-                Program.start_at.asc().nullsfirst(),
-                desc(Program.priority),
-                Program.id.asc(),
-            )
-            .filter(Program.finished == False)  # noqa
-            .all()
+        pending = (
+            session.query(Program).filter(Program.finished == False).count()  # noqa
         )
+        log.debug(f"rescheduling, found {pending} runnable programs")
+        if pending:
+            machine.wake_up()
 
-        if not programs:
-            return
-
-        log.debug(f"rescheduling, found {len(list(programs))} runnable programs")
-
-        for program in programs:
-            self.run_queue.put(program)
-
-        machine.wake_up()
+    def _now_mjd(self):
+        try:
+            return float(self.machine.controller.get_site().mjd())
+        except Exception:
+            log.exception("No site clock available; using the static time order.")
+            return None
 
     def __next__(self):
-        session = Session()
-        while not self.run_queue.empty():
-            program = self.run_queue.get()
-            # reschedule() also enqueues the currently RUNNING program (its
-            # finished flag is only written at completion), so entries can
-            # be stale by the time they are popped: re-check the database
-            current = session.get(Program, program.id)
-            if current is None or current.finished:
-                continue
-            return program
+        """The highest-priority READY program, else the one ready soonest.
 
-        return None
+        Selection is by time first, but on ELIGIBILITY rather than a static
+        sort: a start_at of 0/None means "no constraint" and one in the past
+        means "overdue", and both are ready NOW - so priority ranks them. A
+        FUTURE start_at makes a program ineligible until its time comes, so
+        a morning flat queued at 22:00 cannot park the machine for 10 h with
+        the whole night queued behind it (2026-07-22).
+
+        Sorting statically by start_at instead starved every pinned program
+        behind a continuous unpinned one: the sentinel 0.0 reads as
+        "earliest", so a monitoring chain that begins a new visit the second
+        the last one ends won every pop, even hours past the pinned
+        program's start_at - the 00:58 timed focus never ran on opd-40
+        2026-07-28 although priority ranked it above the monitor.
+
+        Every call re-queries, so a program that finished while an entry sat
+        in a queue cannot be replayed - the FIFO this replaced needed an
+        explicit staleness re-check for that.
+
+        Programs that errored since the last reschedule are skipped rather
+        than retried forever.
+        """
+        session = Session()
+        pending = session.query(Program).filter(Program.finished == False)  # noqa
+        if self._deferred:
+            pending = pending.filter(Program.id.notin_(self._deferred))
+
+        now = self._now_mjd()
+        if now is None:
+            return pending.order_by(*_STATIC_ORDER).first()
+
+        program = (
+            pending.filter(
+                or_(Program.start_at == None, Program.start_at <= now)  # noqa
+            )
+            .order_by(*_READY_ORDER)
+            .first()
+        )
+
+        if program is None:
+            # nothing is ready yet: hand over whatever becomes ready first
+            # and let the machine wait on its start_at
+            program = pending.order_by(*_WAITING_ORDER).first()
+
+        return program
 
     def done(self, task, error=None):
         if error:
             log.debug(f"Error processing program {str(task)}.")
             log.exception(error)
+            self._deferred.add(task.id)
         else:
             task.finished = True
 

--- a/tests/chimera/controllers/test_scheduler_no_duplicate.py
+++ b/tests/chimera/controllers/test_scheduler_no_duplicate.py
@@ -223,6 +223,50 @@ def test_stop_cancels_a_program_waiting_for_its_slew_time():
     machine.state(State.SHUTDOWN)
 
 
+def _machine_stub(mjd=None):
+    """The bits of Machine the SequentialScheduler touches, with a site clock
+    when the test needs an eligibility decision. mjd=None models a harness
+    with no site at all, where selection falls back to the static order."""
+
+    class Site:
+        @staticmethod
+        def mjd():
+            return mjd
+
+    class MachineController:
+        @staticmethod
+        def get_site():
+            if mjd is None:
+                raise Exception("no site in this harness")
+            return Site()
+
+    return type(
+        "M",
+        (),
+        {"wake_up": staticmethod(lambda: None), "controller": MachineController()},
+    )()
+
+
+def _drain(scheduler):
+    """Run the queue the way the machine does: pick, execute, mark done.
+
+    Selection is a fresh query per call, so an undone program is offered
+    again - draining without done() would spin forever.
+    """
+    from chimera.controllers.scheduler.model import Session
+
+    order = []
+    while True:
+        program = next(scheduler)
+        if program is None:
+            break
+        order.append(program.name)
+        session = Session()
+        scheduler.done(session.merge(program))
+        session.commit()
+    return order
+
+
 def test_sequential_runs_in_time_order():
     """A queue with baked start times must execute chronologically.
 
@@ -240,16 +284,12 @@ def test_sequential_runs_in_time_order():
     session.add(Program(name="evening-flat", priority=0, start_at=61243.86))
     session.commit()
 
+    # 22:00 on the incident night: nothing has reached its start_at yet, so
+    # each program becomes eligible in turn and none can jump the queue
     scheduler = SequentialScheduler()
-    scheduler.reschedule(type("M", (), {"wake_up": staticmethod(lambda: None)})())
+    scheduler.reschedule(_machine_stub(mjd=61243.80))
 
-    order = []
-    while True:
-        program = next(scheduler)
-        if program is None:
-            break
-        order.append(program.name)
-    assert order == ["evening-flat", "science", "morning-flat"], order
+    assert _drain(scheduler) == ["evening-flat", "science", "morning-flat"]
 
     session.query(Program).delete()
     session.commit()
@@ -271,17 +311,81 @@ def test_sequential_keeps_file_order_for_untimed_programs():
         session.add(Program(name=name, priority=0))
     session.commit()
 
+    # no start_at at all: every one is ready, so insertion order decides
     scheduler = SequentialScheduler()
-    scheduler.reschedule(type("M", (), {"wake_up": staticmethod(lambda: None)})())
+    scheduler.reschedule(_machine_stub(mjd=61244.0))
 
-    order = []
-    while True:
-        program = next(scheduler)
-        if program is None:
-            break
-        order.append(program.name)
-    assert order == ["first", "second", "third"], order
+    assert _drain(scheduler) == ["first", "second", "third"]
 
+    session.query(Program).delete()
+    session.commit()
+
+
+def test_sequential_ready_program_beats_an_unpinned_chain():
+    """A pinned program PAST its start_at must not starve behind an
+    unpinned one.
+
+    An unpinned program (start_at 0.0, the "no constraint" sentinel) read
+    as "earliest" under a static time sort, so a monitoring chain that
+    starts a new visit the second the last one ends won every pop - the
+    00:58 timed focus never ran on opd-40 2026-07-28 although priority
+    ranked it above the monitor. Both are ready; priority decides.
+    """
+    from chimera.controllers.scheduler.model import Program, Session
+    from chimera.controllers.scheduler.sequential import SequentialScheduler
+
+    session = Session()
+    session.query(Program).delete()
+    # chimera priority is descending (robobs negates its ascending ranks):
+    # focus -5 outranks monitor -25
+    session.add(Program(name="monitor-1", priority=-25, start_at=0.0))
+    session.add(Program(name="monitor-2", priority=-25, start_at=0.0))
+    session.add(Program(name="focus", priority=-5, start_at=61250.0410))
+    session.commit()
+
+    scheduler = SequentialScheduler()
+
+    # before the focus's time: the monitor runs
+    scheduler.reschedule(_machine_stub(mjd=61250.0000))
+    assert next(scheduler).name == "monitor-1"
+
+    # past it (01:16 against a 00:59 start): the focus is ready and outranks
+    scheduler.reschedule(_machine_stub(mjd=61250.0530))
+    order = _drain(scheduler)
+    assert order == ["focus", "monitor-1", "monitor-2"], order
+
+    session = Session()
+    session.query(Program).delete()
+    session.commit()
+
+
+def test_sequential_errored_program_is_not_retried_forever():
+    """done(error=...) must defer the failing program, or a dynamic pick
+    returns it again immediately and the machine livelocks on it."""
+    from chimera.controllers.scheduler.model import Program, Session
+    from chimera.controllers.scheduler.sequential import SequentialScheduler
+
+    session = Session()
+    session.query(Program).delete()
+    session.add(Program(name="bad-focus", priority=-5, start_at=0.0))
+    session.add(Program(name="science", priority=-25, start_at=0.0))
+    session.commit()
+
+    scheduler = SequentialScheduler()
+    scheduler.reschedule(_machine_stub(mjd=61250.0))
+
+    failing = next(scheduler)
+    assert failing.name == "bad-focus"
+    scheduler.done(failing, error=Exception("Error while autofocusing"))
+
+    picked = next(scheduler)
+    assert picked is not None and picked.name == "science"
+
+    # a reschedule clears the deferral: the program may be retried then
+    scheduler.reschedule(_machine_stub(mjd=61250.0))
+    assert next(scheduler).name == "bad-focus"
+
+    session = Session()
     session.query(Program).delete()
     session.commit()
 
@@ -299,14 +403,14 @@ def test_finished_program_is_not_rerun_after_reschedule():
     session.add(Program(name="science", priority=-19, start_at=61244.20))
     session.commit()
 
-    machine = type("M", (), {"wake_up": staticmethod(lambda: None)})()
+    machine = _machine_stub(mjd=61244.25)  # both are past their start_at
     scheduler = SequentialScheduler()
     scheduler.reschedule(machine)
     running = next(scheduler)
     assert running.name == "focus"
 
-    # robobs hands over another program mid-run: the rebuilt queue holds
-    # the still-unfinished focus again
+    # robobs hands over another program mid-run: the queue is rebuilt while
+    # the focus is still unfinished
     scheduler.reschedule(machine)
 
     # the focus completes, exactly as machine._process does it
@@ -341,7 +445,7 @@ def test_reschedule_during_run_does_not_unbalance_the_queue():
     session.add(Program(name="only", priority=0, start_at=61244.0))
     session.commit()
 
-    machine = type("M", (), {"wake_up": staticmethod(lambda: None)})()
+    machine = _machine_stub(mjd=61244.25)
     scheduler = SequentialScheduler()
     scheduler.reschedule(machine)
     running = next(scheduler)


### PR DESCRIPTION
`reschedule()` sorts by `start_at` first with priority as a tie-break, and `start_at` uses **0.0 as its "no constraint" sentinel** (`machine.py` tests `if program.start_at:`). A static sort reads 0.0 as *earliest*, so an unpinned program outsorts every pinned one — permanently, not just until its time comes.

That starves timed programs behind any continuous unpinned one. On opd-40:

- **2026-07-28, 00:58 UT focus** — handed to the scheduler, then never ran. A monitoring chain (`start_at = 0.0`, priority −25) began a new visit the second the previous ended and won every pop, while the focus (priority −5) sat 17+ minutes past its `start_at`. Priority never entered: the tie-break only applies at *equal* `start_at`.
- **2026-07-27, 06:59 UT focus** — same mechanism, same outcome.

The queue at the time, ordered as the scheduler saw it:

| id | program | priority | start_at |
|---|---|---|---|
| 23–27 | WASP-145A ×5 | −25 | **0.0** |
| 28 | SAO 206608 (focus) | −5 | 00:59 |

### What changes

Selection becomes dynamic, judged against the site clock rather than a precomputed sort:

- **ready now** — `start_at` null/0 (no constraint) or already passed (overdue). Among these, priority decides, then earliest `start_at`, then insertion order.
- **nothing ready** — hand over whichever becomes ready first and let the machine wait on its `start_at`.

A *future* `start_at` therefore makes a program ineligible, which is what the 2026-07-22 fix was reaching for: a morning flat queued at 22:00 still cannot park the machine for 10 h, whatever its priority. The insertion-order tie-break from the file-order fix is kept, so a hand-written `chimera-sched --new` queue still runs in YAML order.

Two consequences worth naming:

- Re-querying per call **subsumes the FIFO's staleness re-check** — a program that finished while its entry sat in a queue cannot be replayed, because every selection filters `finished == False`. The `run_queue` goes away.
- A dynamic pick would otherwise **livelock on a failing program** (it is immediately eligible again), so `done(error=...)` defers it until the next `reschedule()` — the FIFO did this implicitly by popping.

### Testing

10 tests, including the two prior regressions restated as behaviour: the 2026-07-22 morning-flat starvation, and file order for untimed queues. Two new ones cover this bug — a ready pinned program beating an unpinned chain, and the errored-program deferral — and the first is confirmed to fail on `master`.

Note the drain helper marks each program done: with per-call selection an undone program is legitimately offered again, so a bare `while next(scheduler)` loop spins forever. That is a real behavioural difference from the FIFO and the tests say so explicitly.

**Validated on sky** on the night of 2026-07-29: a timed focus preempted a continuous monitoring chain at the first block boundary after becoming due, three times — twice unattended.
