### PR TITLE
site: add moon_ra_dec(), a moon position that crosses the bus

### DIFF
--- a/src/chimera/core/site.py
+++ b/src/chimera/core/site.py
@@ -271,6 +271,23 @@ class Site(ChimeraObject):
             Coord.from_r(self._moon.alt), Coord.from_r(self._moon.az)
         )
 
+    def moon_ra_dec(self, date=None):
+        """
+        Moon apparent TOPOCENTRIC position as (ra in HOURS, dec in DEGREES).
+
+        The companion to sun_altitude()/sun_azimuth(): moonpos() returns a
+        Position, which does not cross the bus. Computed against the
+        observer, so the ~1 degree of horizontal parallax is included.
+
+        @rtype: tuple(float, float)
+        """
+        date = date or self.ut()
+        self._moon.compute(self._get_ephem(date))
+        return (
+            float(Coord.from_r(self._moon.ra).to_h()),
+            float(Coord.from_r(self._moon.dec).to_d()),
+        )
+
     def moonphase(self, date=None):
         # NOTE(thread-safety): compute-then-read race on the shared _moon
         # body, same as sunpos.

--- a/tests/chimera/core/test_site.py
+++ b/tests/chimera/core/test_site.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2006-present Paulo Henrique Silva <ph.silva@gmail.com>
 
 import datetime as dt
+import math
 import time
 
 import msgspec
@@ -114,3 +115,36 @@ class TestSite:
                 when + dt.timedelta(minutes=1)
             ) < site.sun_altitude(when)
             assert site.is_dusk(when) is descending, f"{when} is not settled"
+
+    def test_moon_ra_dec_survives_the_bus_and_includes_parallax(self, manager):
+        """moonpos() cannot be encoded and a bare pyephem Moon is geocentric:
+        this must cross the bus AND include the observer's parallax."""
+        import ephem
+
+        site = manager.get_proxy("/Site/0")
+        when = dt.datetime(2026, 7, 31, 3, 0, tzinfo=dt.UTC)
+
+        ra, dec = site.moon_ra_dec(when)
+
+        encoder = msgspec.json.Encoder()
+        assert encoder.encode(site.moon_ra_dec())
+        with pytest.raises(TypeError):
+            encoder.encode(site.moonpos())
+
+        assert 0.0 <= ra < 24.0
+        assert -90.0 <= dec <= 90.0
+
+        # geocentric, for contrast
+        geo = ephem.Moon()
+        geo.compute(when.strftime("%Y/%m/%d %H:%M:%S"))
+        geo_ra = math.degrees(float(geo.ra)) / 15.0
+        geo_dec = math.degrees(float(geo.dec))
+
+        sep = math.hypot(
+            (ra - geo_ra) * 15.0 * math.cos(math.radians(dec)), dec - geo_dec
+        )
+        assert sep > 0.05, (
+            f"moon_ra_dec() returned the geocentric position (sep {sep:.3f} deg); "
+            "it must be computed against the observer"
+        )
+        assert sep < 1.5, f"parallax should be under ~1 deg, got {sep:.3f}"


### PR DESCRIPTION
`moonpos()` returns a `Position`, which is not msgspec-encodable, so anything reading the moon through a proxy either fails outright or works only by accident when it happens to share a bus with the site:

```
TypeError: Encoding objects of type Position is unsupported
```

This adds `Site.moon_ra_dec()`, returning `(ra in hours, dec in degrees)` as plain floats. Same shape and same reason as the `sun_altitude()` / `sun_azimuth()` pair added in #275 and #282.

### It also fixes an accuracy bug, not just an encoding one

Consumers that could not use `moonpos()` have been recomputing the moon themselves with a bare `ephem.Moon()`. That gives the **geocentric** position — up to ~1 degree from the observer's, the moon's horizontal parallax. chimera-robobs carried exactly that workaround, with the approximation written into its docstring as acceptable:

```python
def moon_ra_dec(self, date=None):
    """Geocentric moon (ra [hours], dec [degrees])."""
    moon = ephem.Moon()
    moon.compute(to_ephem_date(date))
    return math.degrees(float(moon.ra)) / 15.0, math.degrees(float(moon.dec))
```

It is acceptable against a 10-30 degree moon-distance limit and wrong for anything tighter — and there is no reason for a plugin to carry its own ephemeris in order to get a worse answer than core already has. `moon_ra_dec()` computes against `_get_ephem(date)`, so the parallax is included.

### Test

`test_moon_ra_dec_survives_the_bus_and_includes_parallax` asserts both halves:

- the result encodes, while `moonpos()` still raises `TypeError` — the encoding half;
- the result differs from a bare geocentric `ephem.Moon()` by more than 0.05 deg, and by less than 1.5 deg — the accuracy half.

That second assertion is the one that matters: an implementation that drops the observer would still return a plausible-looking moon and would pass a range check. It fails this one.

Full suite: **317 passed, 8 skipped**.

### Context

Found while chasing a real failure at the LNA 0.4 m (opd-40): the same `Position`-over-the-bus problem in `sun_altitude()` aborted `make-queue` for the calibration project, and a whole night's sky flats were silently not queued — the CLI logged the `TypeError` and the wrapper script reported "no targets tonight". The sun half is fixed by #275/#282; this is the moon half.

Related: #288, which proposes having the proxy marshal return values from the methods' type annotations, so this class of workaround stops being necessary at all.
