### PR TITLE
dome: report the live mode in DOME_TRK, not the config option

### DIFF
--- a/src/chimera/instruments/dome.py
+++ b/src/chimera/instruments/dome.py
@@ -236,7 +236,8 @@ class DomeBase(ChimeraObject, DomeSlew, DomeSlit, DomeSync):
         metadata = [
             ("DOME_MDL", str(self["model"]), "Dome Model"),
             ("DOME_TYP", str(self["style"]), "Dome Type"),
-            ("DOME_TRK", str(self["mode"]), "Dome Tracking/Standing"),
+            # the live mode: self["mode"] is only the one the dome started in
+            ("DOME_TRK", str(self.get_mode()), "Dome Tracking/Standing"),
             ("DOME_SLT", str(slit), "Dome slit status"),
         ]
 

--- a/tests/chimera/instruments/test_dome_wind_screen.py
+++ b/tests/chimera/instruments/test_dome_wind_screen.py
@@ -200,6 +200,25 @@ def test_metadata_carries_the_wind_screen_altitude(dome):
     assert metadata["DOME_WSC"] == "35.00"
 
 
+def test_metadata_reports_the_live_mode(manager):
+    """DOME_TRK follows track()/stand(), not the mode the dome started in."""
+    from chimera.instruments.faketelescope import FakeTelescope
+
+    manager.add_class(FakeTelescope, "modes")
+    dome = manager.add_class(
+        FakeDome, "modes", {"telescope": "/FakeTelescope/modes", "mode": Mode.Stand}
+    )
+
+    def reported():
+        return dict((key, value) for key, value, _ in dome.get_metadata({}))["DOME_TRK"]
+
+    assert reported() == "Stand"
+    dome.track()
+    assert reported() == "Track"
+    dome.stand()
+    assert reported() == "Stand"
+
+
 def test_metadata_carries_the_flap_status(dome):
     metadata = dict((key, value) for key, value, _ in dome.get_metadata({}))
     assert metadata["DOME_FLP"] == "Closed"


### PR DESCRIPTION
`DomeBase.get_metadata` filled `DOME_TRK` from `self["mode"]` — the
*configuration option* — so the card reported the mode the dome **started
in** and never changed again. `track()` and `stand()` move `self._mode`,
which the header never consulted.

Every frame of a night therefore carries the same value whatever the dome
has done since. That is the opposite of what the card is for: a dome that
stops following the telescope produces frames that look entirely normal
apart from having no stars in them, and `DOME_TRK` is the one field in the
header that could have said so.

`get_mode()` is the live state, and `str()` of the `Mode` enum yields the
same `Track`/`Stand` text the option did, so the card's format is unchanged.

Found while working out why a night of frames came out empty: the header
claimed `Stand` on every frame of every night in an archive, which turned
out to be the configured startup value rather than anything the dome was
doing — while the control loop was demonstrably queueing tracking slews.

## Test

`test_metadata_reports_the_live_mode` asserts the card follows `track()`
and `stand()`. `tests/chimera/instruments/test_dome_wind_screen.py`: 24
passed.